### PR TITLE
Created simplistic implementation for AmazonDynamoDBAsyncClient

### DIFF
--- a/src/main/java/com/michelboudreau/alternator/AlternatorDBAsyncClient.java
+++ b/src/main/java/com/michelboudreau/alternator/AlternatorDBAsyncClient.java
@@ -1,0 +1,136 @@
+package com.michelboudreau.alternator;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import com.amazonaws.AmazonClientException;
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.services.dynamodb.AmazonDynamoDBAsync;
+import com.amazonaws.services.dynamodb.model.BatchGetItemRequest;
+import com.amazonaws.services.dynamodb.model.BatchGetItemResult;
+import com.amazonaws.services.dynamodb.model.BatchWriteItemRequest;
+import com.amazonaws.services.dynamodb.model.BatchWriteItemResult;
+import com.amazonaws.services.dynamodb.model.CreateTableRequest;
+import com.amazonaws.services.dynamodb.model.CreateTableResult;
+import com.amazonaws.services.dynamodb.model.DeleteItemRequest;
+import com.amazonaws.services.dynamodb.model.DeleteItemResult;
+import com.amazonaws.services.dynamodb.model.DeleteTableRequest;
+import com.amazonaws.services.dynamodb.model.DeleteTableResult;
+import com.amazonaws.services.dynamodb.model.DescribeTableRequest;
+import com.amazonaws.services.dynamodb.model.DescribeTableResult;
+import com.amazonaws.services.dynamodb.model.GetItemRequest;
+import com.amazonaws.services.dynamodb.model.GetItemResult;
+import com.amazonaws.services.dynamodb.model.ListTablesRequest;
+import com.amazonaws.services.dynamodb.model.ListTablesResult;
+import com.amazonaws.services.dynamodb.model.PutItemRequest;
+import com.amazonaws.services.dynamodb.model.PutItemResult;
+import com.amazonaws.services.dynamodb.model.QueryRequest;
+import com.amazonaws.services.dynamodb.model.QueryResult;
+import com.amazonaws.services.dynamodb.model.ScanRequest;
+import com.amazonaws.services.dynamodb.model.ScanResult;
+import com.amazonaws.services.dynamodb.model.UpdateItemRequest;
+import com.amazonaws.services.dynamodb.model.UpdateItemResult;
+import com.amazonaws.services.dynamodb.model.UpdateTableRequest;
+import com.amazonaws.services.dynamodb.model.UpdateTableResult;
+
+public class AlternatorDBAsyncClient extends AlternatorDBClient implements AmazonDynamoDBAsync {
+	@Override
+	public Future<ListTablesResult> listTablesAsync(ListTablesRequest listTablesRequest) throws AmazonServiceException, AmazonClientException {
+		return new FakeFuture<ListTablesResult>(listTables(listTablesRequest));
+	}
+
+	@Override
+	public Future<QueryResult> queryAsync(QueryRequest queryRequest) throws AmazonServiceException, AmazonClientException {
+		return new FakeFuture<QueryResult>(query(queryRequest));
+	}
+
+	@Override
+	public Future<BatchWriteItemResult> batchWriteItemAsync(BatchWriteItemRequest batchWriteItemRequest) throws AmazonServiceException, AmazonClientException {
+		return new FakeFuture<BatchWriteItemResult>(batchWriteItem(batchWriteItemRequest));
+	}
+
+	@Override
+	public Future<UpdateItemResult> updateItemAsync(UpdateItemRequest updateItemRequest) throws AmazonServiceException, AmazonClientException {
+		return new FakeFuture<UpdateItemResult>(updateItem(updateItemRequest));
+	}
+
+	@Override
+	public Future<PutItemResult> putItemAsync(PutItemRequest putItemRequest) throws AmazonServiceException, AmazonClientException {
+		return new FakeFuture<PutItemResult>(putItem(putItemRequest));
+	}
+
+	@Override
+	public Future<DescribeTableResult> describeTableAsync(DescribeTableRequest describeTableRequest) throws AmazonServiceException, AmazonClientException {
+		return new FakeFuture<DescribeTableResult>(describeTable(describeTableRequest));
+	}
+
+	@Override
+	public Future<ScanResult> scanAsync(ScanRequest scanRequest) throws AmazonServiceException, AmazonClientException {
+		return new FakeFuture<ScanResult>(scan(scanRequest));
+	}
+
+	@Override
+	public Future<CreateTableResult> createTableAsync(CreateTableRequest createTableRequest) throws AmazonServiceException, AmazonClientException {
+		return new FakeFuture<CreateTableResult>(createTable(createTableRequest));
+	}
+
+	@Override
+	public Future<UpdateTableResult> updateTableAsync(UpdateTableRequest updateTableRequest) throws AmazonServiceException, AmazonClientException {
+		return new FakeFuture<UpdateTableResult>(updateTable(updateTableRequest));
+	}
+
+	@Override
+	public Future<DeleteTableResult> deleteTableAsync(DeleteTableRequest deleteTableRequest) throws AmazonServiceException, AmazonClientException {
+		return new FakeFuture<DeleteTableResult>(deleteTable(deleteTableRequest));
+	}
+
+	@Override
+	public Future<DeleteItemResult> deleteItemAsync(DeleteItemRequest deleteItemRequest) throws AmazonServiceException, AmazonClientException {
+		return new FakeFuture<DeleteItemResult>(deleteItem(deleteItemRequest));
+	}
+
+	@Override
+	public Future<GetItemResult> getItemAsync(GetItemRequest getItemRequest) throws AmazonServiceException, AmazonClientException {
+		return new FakeFuture<GetItemResult>(getItem(getItemRequest));
+	}
+
+	@Override
+	public Future<BatchGetItemResult> batchGetItemAsync(BatchGetItemRequest batchGetItemRequest) throws AmazonServiceException, AmazonClientException {
+		return new FakeFuture<BatchGetItemResult>(batchGetItem(batchGetItemRequest));
+	}
+	
+	class FakeFuture<T> implements Future<T> {
+		private final T value;
+
+		public FakeFuture(final T value) {
+			this.value = value;
+		}
+
+		@Override
+		public boolean cancel(final boolean mayInterruptIfRunning) {
+			return false;
+		}
+
+		@Override
+		public T get() throws InterruptedException, ExecutionException {
+			return value;
+		}
+
+		@Override
+		public T get(final long timeout, final TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+			return value;
+		}
+
+		@Override
+		public boolean isCancelled() {
+			return false;
+		}
+
+		@Override
+		public boolean isDone() {
+			return true;
+		}
+	}
+}


### PR DESCRIPTION
In this basic implementation I use FakeFuture instances to wrap results of synchronous AmazonDynamoDBClient calls. This would already allow clients to mock (synchronous and) asynchronous DynamoDB calls with Alternator.

However, I could not verify the change this many of the test cases currently fail. This is what I get when I run mvn clean install after a fresh git clone:

Failed tests: 
  queryWithHashKeyTest(com.michelboudreau.test.AlternatorQueryTest)
  queryWithHashKeyAndAttributesToGetTest(com.michelboudreau.test.AlternatorQueryTest)
  putItemInTableTest(com.michelboudreau.test.AlternatorItemTest): expected:<null> but was:<{testfield={S: test, }, id={S: 123, }, date={N: 56789, }}>
  updateItemInTableTest(com.michelboudreau.test.AlternatorItemTest): expected:<null> but was:<{testfield={S: test, }, id={S: 123, }, date={N: 56789, }}>

Tests in error: 
  queryWithHashKeyAndRangeKeyConditionEQTest(com.michelboudreau.test.AlternatorQueryTest)
  queryWithHashKeyAndRangeKeyConditionGETest(com.michelboudreau.test.AlternatorQueryTest)
  queryWithHashKeyAndRangeKeyConditionGTTest(com.michelboudreau.test.AlternatorQueryTest)
  queryWithHashKeyAndRangeKeyConditionLETest(com.michelboudreau.test.AlternatorQueryTest)
  queryWithHashKeyAndRangeKeyConditionLTTest(com.michelboudreau.test.AlternatorQueryTest)
  queryWithHashKeyAndRangeKeyConditionINTest(com.michelboudreau.test.AlternatorQueryTest)
  queryWithHashKeyAndRangeKeyConditionBETWEENTest(com.michelboudreau.test.AlternatorQueryTest)
  queryWithHashKeyAndLimitTest(com.michelboudreau.test.AlternatorQueryTest)
  basicScanTest(com.michelboudreau.test.AlternatorScanTest)
  scanWithLimitTest(com.michelboudreau.test.AlternatorScanTest)
  scanWithAttributesToGetTest(com.michelboudreau.test.AlternatorScanTest)
  scanWithScanFilterEQTest(com.michelboudreau.test.AlternatorScanTest)
  scanWithScanFilterGETest(com.michelboudreau.test.AlternatorScanTest)
  scanWithScanFilterGTTest(com.michelboudreau.test.AlternatorScanTest)
  scanWithScanFilterLETest(com.michelboudreau.test.AlternatorScanTest)
  scanWithScanFilterLTTest(com.michelboudreau.test.AlternatorScanTest)
  scanWithScanFilterINTest(com.michelboudreau.test.AlternatorScanTest)
  scanWithScanFilterBETWEENTest(com.michelboudreau.test.AlternatorScanTest)
  scanPaginationTest(com.michelboudreau.test.AlternatorScanTest)
  batchGetItemInTableWithoutNameTest(com.michelboudreau.test.AlternatorItemTest): Unable to marshall request to JSON: Null key.

Thanks,
Ingo
