### PR TITLE
Check if the requested attribute exists.

### DIFF
--- a/src/main/java/com/michelboudreau/alternator/AlternatorDBHandler.java
+++ b/src/main/java/com/michelboudreau/alternator/AlternatorDBHandler.java
@@ -314,11 +314,13 @@ class AlternatorDBHandler {
                 result.setItem(this.tables.get(tableName).getItem(keyz));
             } else {
                 for (String att : attributesToGet) {
-                    response.put(att, this.tables.get(tableName).getItem(getKeyValue(key.getHashKeyElement())).get(att));
+                    AttributeValue res = this.tables.get(tableName).getItem(getKeyValue(key.getHashKeyElement())).get(att);
+                    if (res != null) {
+                        response.put(att, res);
+                    }
                 }
                 result.setItem(response);
             }
-
         }
         return result;
     }


### PR DESCRIPTION
This is just a simple fix to check if the requested attribute exists before adding it to the response. This fixes issue #28 which I created last week.

I still haven't confirmed that this is correct behavior of Amazon's DynamoDB (the only confirmation I have is that my tests pass with the original client and they didn't with alternator. After this fix they're back to green with Alternator). I don't have the time to confirm this right now, but if you prefer I can check it when I have time, before you merge this.
