### PR TITLE
Support multiple items with different Range Keys for the same Hash Key.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
 	<groupId>com.michelboudreau</groupId>
 	<artifactId>alternator</artifactId>
-	<version>0.2.15-SNAPSHOT</version>
+	<version>0.2.16-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>Alternator</name>

--- a/src/main/java/com/michelboudreau/alternator/AlternatorDBInProcessClient.java
+++ b/src/main/java/com/michelboudreau/alternator/AlternatorDBInProcessClient.java
@@ -1,0 +1,187 @@
+package com.michelboudreau.alternator;
+
+import com.amazonaws.*;
+import com.amazonaws.services.dynamodb.AmazonDynamoDB;
+import com.amazonaws.services.dynamodb.model.*;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+public class AlternatorDBInProcessClient extends AmazonWebServiceClient implements AmazonDynamoDB {
+	private static final Log log = LogFactory.getLog(AlternatorDBInProcessClient.class);
+
+    private AlternatorDBHandler handler = new AlternatorDBHandler();
+
+	public AlternatorDBInProcessClient() {
+		this(new ClientConfiguration());
+	}
+
+	public AlternatorDBInProcessClient(ClientConfiguration clientConfiguration) {
+		super(clientConfiguration);
+		init();
+	}
+
+	private void init() {
+	}
+
+	public ListTablesResult listTables(ListTablesRequest listTablesRequest)
+			throws AmazonServiceException, AmazonClientException {
+
+        try {
+            return handler.listTables(listTablesRequest);
+        } catch (Exception e) {
+            log.error(e.getMessage(), e);
+            return new ListTablesResult();
+        }
+	}
+
+	public QueryResult query(QueryRequest queryRequest)
+			throws AmazonServiceException, AmazonClientException {
+
+        try {
+            return handler.query(queryRequest);
+        } catch (Exception e) {
+            log.error(e.getMessage(), e);
+            return new QueryResult();
+        }
+	}
+
+	public BatchWriteItemResult batchWriteItem(BatchWriteItemRequest batchWriteItemRequest)
+			throws AmazonServiceException, AmazonClientException {
+
+        try {
+            return handler.batchWriteItem(batchWriteItemRequest);
+        } catch (Exception e) {
+            log.error(e.getMessage(), e);
+            return new BatchWriteItemResult();
+        }
+}
+
+	public UpdateItemResult updateItem(UpdateItemRequest updateItemRequest)
+			throws AmazonServiceException, AmazonClientException {
+
+        try {
+            return handler.updateItem(updateItemRequest);
+        } catch (Exception e) {
+            log.error(e.getMessage(), e);
+            return new UpdateItemResult();
+        }
+	}
+
+	public PutItemResult putItem(PutItemRequest putItemRequest)
+			throws AmazonServiceException, AmazonClientException {
+
+        try {
+            return handler.putItem(putItemRequest);
+	    } catch (Exception e) {
+            log.error(e.getMessage(), e);
+            return new PutItemResult();
+        }
+}
+
+	public DescribeTableResult describeTable(DescribeTableRequest describeTableRequest)
+			throws AmazonServiceException, AmazonClientException {
+
+        try {
+            return handler.describeTable(describeTableRequest);
+        } catch (Exception e) {
+            log.error(e.getMessage(), e);
+            return new DescribeTableResult();
+        }
+	}
+
+	public ScanResult scan(ScanRequest scanRequest)
+			throws AmazonServiceException, AmazonClientException {
+
+        try {
+            return handler.scan(scanRequest);
+        } catch (Exception e) {
+            log.error(e.getMessage(), e);
+            return new ScanResult();
+        }
+	}
+
+	public CreateTableResult createTable(CreateTableRequest createTableRequest)
+			throws AmazonServiceException, AmazonClientException {
+
+        try {
+            return handler.createTable(createTableRequest);
+        } catch (Exception e) {
+            log.error(e.getMessage(), e);
+            return new CreateTableResult();
+        }
+	}
+
+	public UpdateTableResult updateTable(UpdateTableRequest updateTableRequest)
+			throws AmazonServiceException, AmazonClientException {
+
+        try {
+            return handler.updateTable(updateTableRequest);
+        } catch (Exception e) {
+            log.error(e.getMessage(), e);
+            return new UpdateTableResult();
+        }
+	}
+
+	public DeleteTableResult deleteTable(DeleteTableRequest deleteTableRequest)
+			throws AmazonServiceException, AmazonClientException {
+
+        try {
+            return handler.deleteTable(deleteTableRequest);
+        } catch (Exception e) {
+            log.error(e.getMessage(), e);
+            return new DeleteTableResult();
+        }
+	}
+
+	public DeleteItemResult deleteItem(DeleteItemRequest deleteItemRequest)
+			throws AmazonServiceException, AmazonClientException {
+
+        try {
+            return handler.deleteItem(deleteItemRequest);
+        } catch (Exception e) {
+            log.error(e.getMessage(), e);
+            return new DeleteItemResult();
+        }
+    }
+
+	public GetItemResult getItem(GetItemRequest getItemRequest)
+			throws AmazonServiceException, AmazonClientException {
+
+        try {
+            return handler.getItem(getItemRequest);
+        } catch (Exception e) {
+            log.error(e.getMessage(), e);
+            return new GetItemResult();
+        }
+	}
+
+	public BatchGetItemResult batchGetItem(BatchGetItemRequest batchGetItemRequest)
+			throws AmazonServiceException, AmazonClientException {
+
+        try {
+            return handler.batchGetItem(batchGetItemRequest);
+        } catch (Exception e) {
+            log.error(e.getMessage(), e);
+            return new BatchGetItemResult();
+        }
+	}
+
+	public ListTablesResult listTables() throws AmazonServiceException, AmazonClientException {
+        try {
+            return listTables(new ListTablesRequest());
+        } catch (Exception e) {
+            log.error(e.getMessage(), e);
+            return new ListTablesResult();
+        }
+	}
+
+	@Override
+	public void setEndpoint(String endpoint) throws IllegalArgumentException {
+		super.setEndpoint(endpoint);
+	}
+
+    @Override
+	public ResponseMetadata getCachedResponseMetadata(AmazonWebServiceRequest request) {
+		return client.getResponseMetadataForRequest(request);
+	}
+}

--- a/src/main/java/com/michelboudreau/alternator/models/ItemRangeGroup.java
+++ b/src/main/java/com/michelboudreau/alternator/models/ItemRangeGroup.java
@@ -1,0 +1,132 @@
+package com.michelboudreau.alternator.models;
+
+import com.amazonaws.services.dynamodb.model.AttributeValue;
+import com.amazonaws.services.dynamodb.model.Condition;
+import com.amazonaws.services.dynamodb.model.ResourceNotFoundException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+public class ItemRangeGroup {
+    private final String DEFAULT_RANGE_KEY_VALUE = "";
+
+    private SortedMap<String, Map<String, AttributeValue>> items = new TreeMap<String, Map<String, AttributeValue>>();
+
+    public int size() {
+        return items.size();
+    }
+
+    public Set<String> getKeySet() {
+        return items.keySet();
+    }
+
+    public Collection<Map<String, AttributeValue>> getItems(Condition rangeKeyCondition) {
+        if (rangeKeyCondition == null) {
+            return items.values();
+        } else {
+            return filterItemsByRangeKeyCondition(rangeKeyCondition);
+        }
+    }
+
+    private Collection<Map<String, AttributeValue>> filterItemsByRangeKeyCondition(Condition cond) {
+        Collection<Map<String, AttributeValue>> filteredItems = new ArrayList<Map<String, AttributeValue>>();
+
+        for (String rangeKey : items.keySet()) {
+            Map<String, AttributeValue> item = items.get(rangeKey);
+
+            if (cond.getComparisonOperator() == null) {
+                throw new ResourceNotFoundException("There must be a comparisonOperator");
+            }
+            else if (cond.getComparisonOperator().equals("EQ")) {
+                if (cond.getAttributeValueList().size() == 1) {
+                    if (rangeKey.equals(cond.getAttributeValueList().get(0).getS())) {
+                        filteredItems.add(item);
+                    }
+                }
+            }
+            else if (cond.getComparisonOperator().equals("LE")) {
+                if (cond.getAttributeValueList().size() == 1) {
+                    if (rangeKey.compareTo(cond.getAttributeValueList().get(0).getS()) <= 0) {
+                        filteredItems.add(item);
+                    }
+                }
+            }
+            else if (cond.getComparisonOperator().equals("LT")) {
+                if (cond.getAttributeValueList().size() == 1) {
+                    if (rangeKey.compareTo(cond.getAttributeValueList().get(0).getS()) < 0) {
+                        filteredItems.add(item);
+                    }
+                }
+            }
+            else if (cond.getComparisonOperator().equals("GE")) {
+                if (cond.getAttributeValueList().size() == 1) {
+                    if (rangeKey.compareTo(cond.getAttributeValueList().get(0).getS()) >= 0) {
+                        filteredItems.add(item);
+                    }
+                }
+            }
+            else if (cond.getComparisonOperator().equals("GT")) {
+                if (cond.getAttributeValueList().size() == 1) {
+                    if (rangeKey.compareTo(cond.getAttributeValueList().get(0).getS()) > 0) {
+                        filteredItems.add(item);
+                    }
+                }
+            }
+            else if (cond.getComparisonOperator().equals("BETWEEN")) {
+                if (cond.getAttributeValueList().size() == 2) {
+                    if ((rangeKey.compareTo(cond.getAttributeValueList().get(0).getS()) >= 0) &&
+                        (rangeKey.compareTo(cond.getAttributeValueList().get(1).getS()) <= 0)) {
+                        filteredItems.add(item);
+                    }
+                }
+            }
+            else if (cond.getComparisonOperator().equals("BEGINS_WITH")) {
+                if (cond.getAttributeValueList().size() == 1) {
+                    if (rangeKey.startsWith(cond.getAttributeValueList().get(0).getS())) {
+                        filteredItems.add(item);
+                    }
+                }
+            }
+            else if (cond.getComparisonOperator().equals("CONTAINS")) {
+                if (cond.getAttributeValueList().size() == 1) {
+                    if (rangeKey.contains(cond.getAttributeValueList().get(0).getS())) {
+                        filteredItems.add(item);
+                    }
+                }
+            }
+            else if (cond.getComparisonOperator().equals("IN")) {
+                for(AttributeValue value : cond.getAttributeValueList()){
+                    if(rangeKey.equals(value.getS())){
+                        filteredItems.add(item);
+                        break; // out of 'for' loop
+                    }
+                }
+            }
+        }
+
+        return filteredItems;
+    }
+
+	public void putItem(String rangeKeyValue, Map<String, AttributeValue> item) {
+        items.put(normalizeRangeKeyValue(rangeKeyValue), item);
+	}
+
+	public void removeItem(String rangeKeyValue) {
+        items.remove(normalizeRangeKeyValue(rangeKeyValue));
+	}
+
+	public Map<String, AttributeValue> getItem(String rangeKeyValue) {
+        return items.get(normalizeRangeKeyValue(rangeKeyValue));
+	}
+
+    private String normalizeRangeKeyValue(String rangeKeyValue) {
+        String actualRangeKeyValue = rangeKeyValue;
+        if (rangeKeyValue == null) {
+            actualRangeKeyValue = DEFAULT_RANGE_KEY_VALUE;
+        }
+        return actualRangeKeyValue;
+    }
+}

--- a/src/test/java/com/michelboudreau/test/AlternatorBatchItemTest.java
+++ b/src/test/java/com/michelboudreau/test/AlternatorBatchItemTest.java
@@ -31,7 +31,7 @@ public class AlternatorBatchItemTest extends AlternatorTest {
         tableName1 = createTableName();
         TableDescription tableDescription1 = createTable(tableName1);
         hashKeyValue1 = tableDescription1.getKeySchema().getHashKeyElement().getAttributeName();
-        
+
         tableName2 = createTableName();
         TableDescription tableDescription2 = createTable(tableName2);
         hashKeyValue2 = tableDescription2.getKeySchema().getHashKeyElement().getAttributeName();
@@ -87,7 +87,7 @@ public class AlternatorBatchItemTest extends AlternatorTest {
         requestItems.put(tableName2, keysAndAttributes1);
 
         batchGetItemRequest.withRequestItems(requestItems);
-		BatchGetItemResult result  = client.batchGetItem(batchGetItemRequest);
+		BatchGetItemResult result  = getClient().batchGetItem(batchGetItemRequest);
 
 	}
 
@@ -159,7 +159,7 @@ public class AlternatorBatchItemTest extends AlternatorTest {
             System.out.println("Making the request.");
 
             batchWriteItemRequest.withRequestItems(requestItems);
-            result = client.batchWriteItem(batchWriteItemRequest);
+            result = getClient().batchWriteItem(batchWriteItemRequest);
 
             // Print consumed capacity units
             for(Map.Entry<String, BatchWriteResponse> entry : result.getResponses().entrySet()) {

--- a/src/test/java/com/michelboudreau/test/AlternatorItemTest.java
+++ b/src/test/java/com/michelboudreau/test/AlternatorItemTest.java
@@ -44,7 +44,7 @@ public class AlternatorItemTest extends AlternatorTest {
         KeySchema schema = new KeySchema(new KeySchemaElement().withAttributeName("id").withAttributeType(ScalarAttributeType.S));
         createTable(tableName, schema);
         PutItemRequest request = new PutItemRequest().withTableName(tableName).withItem(createGenericItem());
-        PutItemResult res = client.putItem(request);
+        PutItemResult res = getClient().putItem(request);
         Assert.assertNotNull(res);
         Assert.assertNotNull(res.getConsumedCapacityUnits());
     }
@@ -55,8 +55,8 @@ public class AlternatorItemTest extends AlternatorTest {
         KeySchema schema = new KeySchema(new KeySchemaElement().withAttributeName("id").withAttributeType(ScalarAttributeType.S));
         createTable(tableName, schema);
         PutItemRequest request = new PutItemRequest().withTableName(tableName).withItem(createGenericItem());
-        client.putItem(request); // put item beforehand
-        PutItemResult res = client.putItem(request); // Add another
+        getClient().putItem(request); // put item beforehand
+        PutItemResult res = getClient().putItem(request); // Add another
         Assert.assertNotNull(res);
         Assert.assertNotNull(res.getConsumedCapacityUnits());
     }
@@ -66,7 +66,7 @@ public class AlternatorItemTest extends AlternatorTest {
         KeySchema schema = new KeySchema(new KeySchemaElement().withAttributeName("id").withAttributeType(ScalarAttributeType.S));
         createTable(tableName, schema);
         PutItemRequest request = new PutItemRequest().withTableName(tableName);
-        PutItemResult res = client.putItem(request);
+        PutItemResult res = getClient().putItem(request);
         Assert.assertNull(res.getConsumedCapacityUnits());
     }
 
@@ -75,7 +75,7 @@ public class AlternatorItemTest extends AlternatorTest {
         KeySchema schema = new KeySchema(new KeySchemaElement().withAttributeName("id").withAttributeType(ScalarAttributeType.S));
         createTable(tableName, schema);
         PutItemRequest request = new PutItemRequest().withItem(createGenericItem());
-        PutItemResult res = client.putItem(request);
+        PutItemResult res = getClient().putItem(request);
         Assert.assertNull(res.getConsumedCapacityUnits());
     }
 
@@ -86,7 +86,7 @@ public class AlternatorItemTest extends AlternatorTest {
         schema.setRangeKeyElement(new KeySchemaElement().withAttributeName("range").withAttributeType(ScalarAttributeType.S));
         createTable(tableName, schema);
         PutItemRequest request = new PutItemRequest().withTableName(tableName).withItem(createGenericItem());
-        PutItemResult res = client.putItem(request);
+        PutItemResult res = getClient().putItem(request);
         Assert.assertNotNull(res);
         Assert.assertNotNull(res.getConsumedCapacityUnits());
     }
@@ -97,8 +97,8 @@ public class AlternatorItemTest extends AlternatorTest {
         schema.setRangeKeyElement(new KeySchemaElement().withAttributeName("range").withAttributeType(ScalarAttributeType.S));
         createTable(tableName, schema);
         PutItemRequest request = new PutItemRequest().withTableName(tableName).withItem(createGenericItem());
-        client.putItem(request); // put item beforehand
-        PutItemResult res = client.putItem(request); // Add another
+        getClient().putItem(request); // put item beforehand
+        PutItemResult res = getClient().putItem(request); // Add another
         Assert.assertNotNull(res);
         Assert.assertNotNull(res.getConsumedCapacityUnits());
     }
@@ -109,7 +109,7 @@ public class AlternatorItemTest extends AlternatorTest {
         schema.setRangeKeyElement(new KeySchemaElement().withAttributeName("range").withAttributeType(ScalarAttributeType.S));
         createTable(tableName, schema);
         PutItemRequest request = new PutItemRequest().withTableName(tableName);
-        PutItemResult res = client.putItem(request);
+        PutItemResult res = getClient().putItem(request);
         Assert.assertNull(res.getConsumedCapacityUnits());
     }
 
@@ -119,7 +119,7 @@ public class AlternatorItemTest extends AlternatorTest {
         schema.setRangeKeyElement(new KeySchemaElement().withAttributeName("range").withAttributeType(ScalarAttributeType.S));
         createTable(tableName, schema);
         PutItemRequest request = new PutItemRequest().withItem(createGenericItem());
-        PutItemResult res = client.putItem(request);
+        PutItemResult res = getClient().putItem(request);
         Assert.assertNull(res.getConsumedCapacityUnits());
     }
 
@@ -131,7 +131,7 @@ public class AlternatorItemTest extends AlternatorTest {
         AttributeValue hash = createItem(tableName);
         GetItemRequest request = new GetItemRequest().withTableName(tableName);
         request.setKey(new Key().withHashKeyElement(hash));
-        GetItemResult res = client.getItem(request);
+        GetItemResult res = getClient().getItem(request);
         Assert.assertNotNull(res.getItem());
         Assert.assertEquals(res.getItem().get("id"), hash);
     }
@@ -140,7 +140,7 @@ public class AlternatorItemTest extends AlternatorTest {
     public void getItemWithoutTableNameTest() {
         GetItemRequest request = new GetItemRequest();
         request.setKey(new Key().withHashKeyElement(new AttributeValue().withNS("123")));
-        GetItemResult res = client.getItem(request);
+        GetItemResult res = getClient().getItem(request);
         Assert.assertNull(res.getItem());
     }
 
@@ -148,7 +148,7 @@ public class AlternatorItemTest extends AlternatorTest {
     public void getItemWithoutKeyTest() {
         GetItemRequest request = new GetItemRequest();
         request.setTableName(tableName);
-        GetItemResult res = client.getItem(request);
+        GetItemResult res = getClient().getItem(request);
         Assert.assertNull(res.getItem());
     }
 
@@ -162,7 +162,7 @@ public class AlternatorItemTest extends AlternatorTest {
         attrToUp.put("updated", update);
         Key key = new Key(hash);
         UpdateItemRequest request = new UpdateItemRequest(tableName, key, attrToUp);
-        UpdateItemResult res = client.updateItem(request);
+        UpdateItemResult res = getClient().updateItem(request);
         Assert.assertNotNull(res);
         Assert.assertNotNull(res.getAttributes());
     }
@@ -179,7 +179,7 @@ public class AlternatorItemTest extends AlternatorTest {
         UpdateItemRequest request = new UpdateItemRequest();
         request.setKey(key);
         request.setAttributeUpdates(attrToUp);
-        UpdateItemResult res = client.updateItem(request);
+        UpdateItemResult res = getClient().updateItem(request);
         Assert.assertNull(res.getConsumedCapacityUnits());
     }
 
@@ -195,7 +195,7 @@ public class AlternatorItemTest extends AlternatorTest {
         UpdateItemRequest request = new UpdateItemRequest();
         request.setTableName(tableName);
         request.setAttributeUpdates(attrToUp);
-        UpdateItemResult res = client.updateItem(request);
+        UpdateItemResult res = getClient().updateItem(request);
         Assert.assertNull(res.getConsumedCapacityUnits());
     }
 
@@ -204,9 +204,9 @@ public class AlternatorItemTest extends AlternatorTest {
         KeySchema schema = new KeySchema(new KeySchemaElement().withAttributeName("id").withAttributeType(ScalarAttributeType.S));
         createTable(tableName, schema);
         AttributeValue hash = new AttributeValue("ad"); //createStringAttribute();
-        client.putItem(new PutItemRequest().withTableName(tableName).withItem(createGenericItem(hash)));
+        getClient().putItem(new PutItemRequest().withTableName(tableName).withItem(createGenericItem(hash)));
         DeleteItemRequest request = new DeleteItemRequest().withTableName(tableName).withKey(new Key(hash));
-        DeleteItemResult result = client.deleteItem(request);
+        DeleteItemResult result = getClient().deleteItem(request);
         Assert.assertNotNull(result.getConsumedCapacityUnits());
     }
 
@@ -215,9 +215,9 @@ public class AlternatorItemTest extends AlternatorTest {
         KeySchema schema = new KeySchema(new KeySchemaElement().withAttributeName("id").withAttributeType(ScalarAttributeType.S));
         createTable(tableName, schema);
         AttributeValue hash = createStringAttribute();
-        client.putItem(new PutItemRequest().withTableName(tableName).withItem(createGenericItem(hash)));
+        getClient().putItem(new PutItemRequest().withTableName(tableName).withItem(createGenericItem(hash)));
         DeleteItemRequest request = new DeleteItemRequest().withKey(new Key(hash));
-        DeleteItemResult result = client.deleteItem(request);
+        DeleteItemResult result = getClient().deleteItem(request);
         Assert.assertNull(result.getConsumedCapacityUnits());
     }
 
@@ -226,7 +226,7 @@ public class AlternatorItemTest extends AlternatorTest {
         KeySchema schema = new KeySchema(new KeySchemaElement().withAttributeName("id").withAttributeType(ScalarAttributeType.S));
         createTable(tableName, schema);
         DeleteItemRequest request = new DeleteItemRequest().withTableName(tableName).withKey(new Key(createStringAttribute()));
-        Assert.assertNull(client.deleteItem(request).getConsumedCapacityUnits());
+        Assert.assertNull(getClient().deleteItem(request).getConsumedCapacityUnits());
     }
 
     // TODO: test out delete item expected and return value
@@ -244,19 +244,19 @@ public class AlternatorItemTest extends AlternatorTest {
         writeRequests.add(writeRequest);
         requestItems.put(tableName, writeRequests);
         batchWriteItemRequest.setRequestItems(requestItems);
-        BatchWriteItemResult result = client.batchWriteItem(batchWriteItemRequest);
+        BatchWriteItemResult result = getClient().batchWriteItem(batchWriteItemRequest);
         Assert.assertNotNull(result);
     }*/
 /*
 	@Test
 	public void batchWriteItemInTableTest() {
-		BatchWriteItemResult result = client.batchWriteItem(generateWriteBatchRequest());
+		BatchWriteItemResult result = getClient().batchWriteItem(generateWriteBatchRequest());
 		Assert.assertNotNull(result);
 	}
 
 	@Test
 	public void batchGetItemInTableTest() {
-		BatchGetItemResult result = client.batchGetItem(generateGetBatchRequest());
+		BatchGetItemResult result = getClient().batchGetItem(generateGetBatchRequest());
 		Assert.assertNotNull(result);
 	}
 
@@ -266,7 +266,7 @@ public class AlternatorItemTest extends AlternatorTest {
 		Map<String, KeysAndAttributes> requestItems = new HashMap<String, KeysAndAttributes>();
 		requestItems.put(testTableName, null);
 		batchGetItemRequest.withRequestItems(requestItems);
-		Assert.assertNull(client.batchGetItem(batchGetItemRequest).getResponses());
+		Assert.assertNull(getClient().batchGetItem(batchGetItemRequest).getResponses());
 	}
 
 	@Test
@@ -276,12 +276,12 @@ public class AlternatorItemTest extends AlternatorTest {
 		Key table1key1 = new Key().withHashKeyElement(new AttributeValue().withS("123"));
 		requestItems.put(null, new KeysAndAttributes().withKeys(table1key1));
 		batchGetItemRequest.withRequestItems(requestItems);
-		Assert.assertNull(client.batchGetItem(batchGetItemRequest).getResponses());
+		Assert.assertNull(getClient().batchGetItem(batchGetItemRequest).getResponses());
 	}
 
 	@Test
 	public void batchGetItemInTableWithoutRequestItemsTest() {
-		Assert.assertNull(client.batchGetItem(new BatchGetItemRequest()).getResponses());
+		Assert.assertNull(getClient().batchGetItem(new BatchGetItemRequest()).getResponses());
 	}
 */
 
@@ -391,7 +391,7 @@ public class AlternatorItemTest extends AlternatorTest {
         AttributeValue hash = createStringAttribute();
         Map<String, AttributeValue> item = createGenericItem(hash);
         PutItemRequest req = new PutItemRequest().withTableName(tableName).withItem(item);
-        client.putItem(req);
+        getClient().putItem(req);
         return hash;
     }
 }

--- a/src/test/java/com/michelboudreau/test/AlternatorQueryTest.java
+++ b/src/test/java/com/michelboudreau/test/AlternatorQueryTest.java
@@ -33,13 +33,13 @@ public class AlternatorQueryTest extends AlternatorTest {
 		KeySchema schema = new KeySchema(new KeySchemaElement().withAttributeName("id").withAttributeType(ScalarAttributeType.S));
 		createTable(tableName, schema);
 		AttributeValue hashKey = createStringAttribute();
-		client.putItem(new PutItemRequest().withItem(createGenericItem()).withTableName(tableName));
-		client.putItem(new PutItemRequest().withItem(createGenericItem(hashKey)).withTableName(tableName));
-		client.putItem(new PutItemRequest().withItem(createGenericItem()).withTableName(tableName));
-		client.putItem(new PutItemRequest().withItem(createGenericItem()).withTableName(tableName));
+		getClient().putItem(new PutItemRequest().withItem(createGenericItem()).withTableName(tableName));
+		getClient().putItem(new PutItemRequest().withItem(createGenericItem(hashKey)).withTableName(tableName));
+		getClient().putItem(new PutItemRequest().withItem(createGenericItem()).withTableName(tableName));
+		getClient().putItem(new PutItemRequest().withItem(createGenericItem()).withTableName(tableName));
 
 		QueryRequest request = new QueryRequest(tableName, hashKey);
-		QueryResult result = client.query(request);
+		QueryResult result = getClient().query(request);
 		Assert.assertNotNull(result.getItems());
 		Assert.assertNotSame(result.getItems().size(), 0);
 		Assert.assertEquals(result.getItems().get(0).get("id"), hashKey);
@@ -52,154 +52,283 @@ public class AlternatorQueryTest extends AlternatorTest {
         KeySchema schema = new KeySchema(new KeySchemaElement().withAttributeName("id").withAttributeType(ScalarAttributeType.S));
         createTable(tableName, schema);
         AttributeValue hashKey = createStringAttribute();
-        client.putItem(new PutItemRequest().withItem(createGenericItem()).withTableName(tableName));
-        client.putItem(new PutItemRequest().withItem(createGenericItem()).withTableName(tableName));
-        client.putItem(new PutItemRequest().withItem(createGenericItem()).withTableName(tableName));
+        getClient().putItem(new PutItemRequest().withItem(createGenericItem()).withTableName(tableName));
+        getClient().putItem(new PutItemRequest().withItem(createGenericItem()).withTableName(tableName));
+        getClient().putItem(new PutItemRequest().withItem(createGenericItem()).withTableName(tableName));
 
         QueryRequest request = new QueryRequest(tableName, hashKey);
         Assert.assertNotNull(request);
-        QueryResult result = client.query(request);
+        QueryResult result = getClient().query(request);
         Assert.assertNotNull(result.getItems());     //result should be null but unfortunately it not.
-        Assert.assertNotSame(result.getItems().size(), 0);
-        Assert.assertNull(result.getItems().get(0).get("id"));
+        Assert.assertSame(result.getItems().size(), 0);
     }
-/*
-	@Test
+
+    private AttributeValue setupTableWithSeveralItems() {
+		KeySchema schema = new KeySchema()
+                .withHashKeyElement(new KeySchemaElement().withAttributeName("id").withAttributeType(ScalarAttributeType.S))
+                .withRangeKeyElement(new KeySchemaElement().withAttributeName("range").withAttributeType(ScalarAttributeType.S))
+                ;
+		createTable(tableName, schema);
+
+		AttributeValue hashKey1 = createStringAttribute();
+		AttributeValue hashKey2 = createStringAttribute();
+
+		getClient().putItem(new PutItemRequest().withItem(createGenericItem()).withTableName(tableName));
+
+        getClient().putItem(new PutItemRequest().withItem(createGenericItem(hashKey1, createStringAttribute("Range4"), "attr1", "value14", "attr2", "value24")).withTableName(tableName));
+		getClient().putItem(new PutItemRequest().withItem(createGenericItem(hashKey1, createStringAttribute("Range3"), "attr1", "value13", "attr2", "value23")).withTableName(tableName));
+		getClient().putItem(new PutItemRequest().withItem(createGenericItem(hashKey1, createStringAttribute("Range2"), "attr1", "value12", "attr2", "value22")).withTableName(tableName));
+		getClient().putItem(new PutItemRequest().withItem(createGenericItem(hashKey1, createStringAttribute("Range1"), "attr1", "value11", "attr2", "value21")).withTableName(tableName));
+		getClient().putItem(new PutItemRequest().withItem(createGenericItem(hashKey1, createStringAttribute("AnotherRange1"), "attr1", "value19", "attr2", "value29")).withTableName(tableName));
+
+		getClient().putItem(new PutItemRequest().withItem(createGenericItem(hashKey2, createStringAttribute("AnotherRange1"), "attr1", "value19", "attr2", "value29")).withTableName(tableName));
+        getClient().putItem(new PutItemRequest().withItem(createGenericItem(hashKey2, createStringAttribute("Range1"), "attr1", "value11", "attr2", "value21")).withTableName(tableName));
+		getClient().putItem(new PutItemRequest().withItem(createGenericItem(hashKey2, createStringAttribute("Range2"), "attr1", "value12", "attr2", "value22")).withTableName(tableName));
+		getClient().putItem(new PutItemRequest().withItem(createGenericItem(hashKey2, createStringAttribute("Range3"), "attr1", "value13", "attr2", "value23")).withTableName(tableName));
+		getClient().putItem(new PutItemRequest().withItem(createGenericItem(hashKey2, createStringAttribute("Range4"), "attr1", "value14", "attr2", "value24")).withTableName(tableName));
+
+        getClient().putItem(new PutItemRequest().withItem(createGenericItem()).withTableName(tableName));
+		getClient().putItem(new PutItemRequest().withItem(createGenericItem()).withTableName(tableName));
+
+        return hashKey1;
+    }
+
+    @Test
 	public void queryWithHashKeyAndAttributesToGetTest() {
-		QueryRequest request = getBasicReq();
-		request.setHashKeyValue(getHashKey());
+        AttributeValue hashKey = setupTableWithSeveralItems();
+
+        QueryRequest request = new QueryRequest().withTableName(tableName).withHashKeyValue(hashKey);
+
 		List<String> attrToGet = new ArrayList<String>();
-		attrToGet.add("date");
-		attrToGet.add("testfield");
+		attrToGet.add("range");
+		attrToGet.add("attr1");
+		attrToGet.add("bogusAttr");
 		request.setAttributesToGet(attrToGet);
-		QueryResult result = client.query(request);
+		QueryResult result = getClient().query(request);
 		Assert.assertNotNull(result);
 		Assert.assertNotNull(result.getItems());
 		Assert.assertNotNull(result.getItems().get(0));
-		Assert.assertFalse(result.getItems().get(0).containsKey("id"));
+		Assert.assertFalse("First item should not contain 'id'.", result.getItems().get(0).containsKey("id"));
+		Assert.assertTrue("First item missing 'range'.", result.getItems().get(0).containsKey("range"));
+		Assert.assertTrue("First item missing 'attr1'.", result.getItems().get(0).containsKey("attr1"));
+		Assert.assertFalse("First item should not contain 'bogusAttr'.", result.getItems().get(0).containsKey("bogusAttr"));
 	}
 
 	@Test
 	public void queryWithHashKeyAndRangeKeyConditionEQTest() {
-		QueryRequest request = getBasicReq();
-		request.setHashKeyValue(getHashKey());
+        AttributeValue hashKey = setupTableWithSeveralItems();
+
+        QueryRequest request = new QueryRequest().withTableName(tableName).withHashKeyValue(hashKey);
+
 		Condition rangeKeyCondition = new Condition();
 		List<AttributeValue> attributeValueList = new ArrayList<AttributeValue>();
-		attributeValueList.add(new AttributeValue().withN("1"));
+//		attributeValueList.add(new AttributeValue().withN("1"));
+		attributeValueList.add(createStringAttribute("Range2"));
 		rangeKeyCondition.setAttributeValueList(attributeValueList);
 		rangeKeyCondition.setComparisonOperator(ComparisonOperator.EQ);
 		request.setRangeKeyCondition(rangeKeyCondition);
-		QueryResult result = client.query(request);
-		Assert.assertNotNull(result);
+		QueryResult result = getClient().query(request);
+		Assert.assertNotNull("Null result.", result);
+		Assert.assertNotNull("No items returned.", result.getItems());
+        Assert.assertEquals("Should return a one item.", 1, result.getItems().size());
 		for (Map<String, AttributeValue> item : result.getItems()) {
-			Assert.assertEquals(item.get("date").getN(), "1");
-		}
-	}
-
-/*
-	@Test
-	public void queryWithHashKeyAndRangeKeyConditionGETest() {
-		QueryRequest request = getBasicReq();
-		Condition rangeKeyCondition = new Condition();
-		List<AttributeValue> attributeValueList = new ArrayList<AttributeValue>();
-		attributeValueList.add(new AttributeValue().withN("1"));
-		rangeKeyCondition.setAttributeValueList(attributeValueList);
-		rangeKeyCondition.setComparisonOperator(ComparisonOperator.GE);
-		request.setRangeKeyCondition(rangeKeyCondition);
-		QueryResult result = client.query(request);
-		Assert.assertNotNull(result);
-		for (Map<String, AttributeValue> item : result.getItems()) {
-			Assert.assertTrue((new Integer(item.get("date").getN())) >= 1);
-		}
-	}
-
-	@Test
-	public void queryWithHashKeyAndRangeKeyConditionGTTest() {
-		QueryRequest request = getBasicReq();
-		Condition rangeKeyCondition = new Condition();
-		List<AttributeValue> attributeValueList = new ArrayList<AttributeValue>();
-		attributeValueList.add(new AttributeValue().withN("1"));
-		rangeKeyCondition.setAttributeValueList(attributeValueList);
-		rangeKeyCondition.setComparisonOperator(ComparisonOperator.GT);
-		request.setRangeKeyCondition(rangeKeyCondition);
-		QueryResult result = client.query(request);
-		Assert.assertNotNull(result);
-		for (Map<String, AttributeValue> item : result.getItems()) {
-			Assert.assertTrue((new Integer(item.get("date").getN())) > 1);
-		}
-	}
-
-	@Test
-	public void queryWithHashKeyAndRangeKeyConditionLETest() {
-		QueryRequest request = getBasicReq();
-		Condition rangeKeyCondition = new Condition();
-		List<AttributeValue> attributeValueList = new ArrayList<AttributeValue>();
-		attributeValueList.add(new AttributeValue().withN("10"));
-		rangeKeyCondition.setAttributeValueList(attributeValueList);
-		rangeKeyCondition.setComparisonOperator(ComparisonOperator.LE);
-		request.setRangeKeyCondition(rangeKeyCondition);
-		QueryResult result = client.query(request);
-		Assert.assertNotNull(result);
-		for (Map<String, AttributeValue> item : result.getItems()) {
-			Assert.assertTrue((new Integer(item.get("date").getN())) <= 1);
+			Assert.assertEquals(item.get("range").getS(), "Range2");
 		}
 	}
 
 	@Test
 	public void queryWithHashKeyAndRangeKeyConditionLTTest() {
-		QueryRequest request = getBasicReq();
+        AttributeValue hashKey = setupTableWithSeveralItems();
+
+        QueryRequest request = new QueryRequest().withTableName(tableName).withHashKeyValue(hashKey);
+
 		Condition rangeKeyCondition = new Condition();
 		List<AttributeValue> attributeValueList = new ArrayList<AttributeValue>();
-		attributeValueList.add(new AttributeValue().withN("10"));
+//		attributeValueList.add(new AttributeValue().withN("1"));
+		attributeValueList.add(createStringAttribute("Range2"));
 		rangeKeyCondition.setAttributeValueList(attributeValueList);
 		rangeKeyCondition.setComparisonOperator(ComparisonOperator.LT);
 		request.setRangeKeyCondition(rangeKeyCondition);
-		QueryResult result = client.query(request);
-		Assert.assertNotNull(result);
+		QueryResult result = getClient().query(request);
+		Assert.assertNotNull("Null result.", result);
+		Assert.assertNotNull("No items returned.", result.getItems());
+        Assert.assertEquals("Should return a two items.", 2, result.getItems().size());
 		for (Map<String, AttributeValue> item : result.getItems()) {
-			Assert.assertTrue((new Integer(item.get("date").getN())) < 1);
+			Assert.assertTrue(item.get("range").getS().compareTo("Range2") < 0);
+		}
+	}
+
+	@Test
+	public void queryWithHashKeyAndRangeKeyConditionLETest() {
+        AttributeValue hashKey = setupTableWithSeveralItems();
+
+        QueryRequest request = new QueryRequest().withTableName(tableName).withHashKeyValue(hashKey);
+
+		Condition rangeKeyCondition = new Condition();
+		List<AttributeValue> attributeValueList = new ArrayList<AttributeValue>();
+//		attributeValueList.add(new AttributeValue().withN("1"));
+		attributeValueList.add(createStringAttribute("Range2"));
+		rangeKeyCondition.setAttributeValueList(attributeValueList);
+		rangeKeyCondition.setComparisonOperator(ComparisonOperator.LE);
+		request.setRangeKeyCondition(rangeKeyCondition);
+		QueryResult result = getClient().query(request);
+		Assert.assertNotNull("Null result.", result);
+		Assert.assertNotNull("No items returned.", result.getItems());
+        Assert.assertEquals("Should return three items.", 3, result.getItems().size());
+		for (Map<String, AttributeValue> item : result.getItems()) {
+			Assert.assertTrue(item.get("range").getS().compareTo("Range2") <= 0);
+		}
+	}
+
+	@Test
+	public void queryWithHashKeyAndRangeKeyConditionGTTest() {
+        AttributeValue hashKey = setupTableWithSeveralItems();
+
+        QueryRequest request = new QueryRequest().withTableName(tableName).withHashKeyValue(hashKey);
+
+		Condition rangeKeyCondition = new Condition();
+		List<AttributeValue> attributeValueList = new ArrayList<AttributeValue>();
+//		attributeValueList.add(new AttributeValue().withN("1"));
+		attributeValueList.add(createStringAttribute("Range2"));
+		rangeKeyCondition.setAttributeValueList(attributeValueList);
+		rangeKeyCondition.setComparisonOperator(ComparisonOperator.GT);
+		request.setRangeKeyCondition(rangeKeyCondition);
+		QueryResult result = getClient().query(request);
+		Assert.assertNotNull("Null result.", result);
+		Assert.assertNotNull("No items returned.", result.getItems());
+        Assert.assertEquals("Should return two items.", 2, result.getItems().size());
+		for (Map<String, AttributeValue> item : result.getItems()) {
+			Assert.assertTrue(item.get("range").getS().compareTo("Range2") > 0);
+		}
+	}
+
+	@Test
+	public void queryWithHashKeyAndRangeKeyConditionGETest() {
+        AttributeValue hashKey = setupTableWithSeveralItems();
+
+        QueryRequest request = new QueryRequest().withTableName(tableName).withHashKeyValue(hashKey);
+
+		Condition rangeKeyCondition = new Condition();
+		List<AttributeValue> attributeValueList = new ArrayList<AttributeValue>();
+//		attributeValueList.add(new AttributeValue().withN("1"));
+		attributeValueList.add(createStringAttribute("Range2"));
+		rangeKeyCondition.setAttributeValueList(attributeValueList);
+		rangeKeyCondition.setComparisonOperator(ComparisonOperator.GE);
+		request.setRangeKeyCondition(rangeKeyCondition);
+		QueryResult result = getClient().query(request);
+		Assert.assertNotNull("Null result.", result);
+		Assert.assertNotNull("No items returned.", result.getItems());
+        Assert.assertEquals("Should return three items.", 3, result.getItems().size());
+		for (Map<String, AttributeValue> item : result.getItems()) {
+			Assert.assertTrue(item.get("range").getS().compareTo("Range2") >= 0);
 		}
 	}
 
 	@Test
 	public void queryWithHashKeyAndRangeKeyConditionINTest() {
-		QueryRequest request = getBasicReq();
+        AttributeValue hashKey = setupTableWithSeveralItems();
+
+        QueryRequest request = new QueryRequest().withTableName(tableName).withHashKeyValue(hashKey);
+
 		Condition rangeKeyCondition = new Condition();
 		List<AttributeValue> attributeValueList = new ArrayList<AttributeValue>();
-		attributeValueList.add(new AttributeValue().withN("5"));
-		attributeValueList.add(new AttributeValue().withN("10"));
+		attributeValueList.add(new AttributeValue().withS("Range2"));
+		attributeValueList.add(new AttributeValue().withS("Range4"));
+		attributeValueList.add(new AttributeValue().withS("Range0"));
 		rangeKeyCondition.setAttributeValueList(attributeValueList);
 		rangeKeyCondition.setComparisonOperator(ComparisonOperator.IN);
 		request.setRangeKeyCondition(rangeKeyCondition);
-		QueryResult result = client.query(request);
-		Assert.assertNotNull(result);
+		QueryResult result = getClient().query(request);
+		Assert.assertNotNull("Null result.", result);
+		Assert.assertNotNull("No items returned.", result.getItems());
+        Assert.assertEquals("Should return two items.", 2, result.getItems().size());
 		for (Map<String, AttributeValue> item : result.getItems()) {
-			Assert.assertTrue((new Integer(item.get("date").getN())) <= 10 && (new Integer(item.get("date").getN())) >= 5);
+			Assert.assertTrue(
+                    (item.get("range").getS().compareTo("Range2") == 0)
+                    ||
+                    (item.get("range").getS().compareTo("Range4") == 0)
+                    );
 		}
 	}
 
 	@Test
 	public void queryWithHashKeyAndRangeKeyConditionBETWEENTest() {
-		QueryRequest request = getBasicReq();
+        AttributeValue hashKey = setupTableWithSeveralItems();
+
+        QueryRequest request = new QueryRequest().withTableName(tableName).withHashKeyValue(hashKey);
+
 		Condition rangeKeyCondition = new Condition();
 		List<AttributeValue> attributeValueList = new ArrayList<AttributeValue>();
-		attributeValueList.add(new AttributeValue().withN("5"));
-		attributeValueList.add(new AttributeValue().withN("10"));
+		attributeValueList.add(new AttributeValue().withS("Range2"));
+		attributeValueList.add(new AttributeValue().withS("Range3"));
 		rangeKeyCondition.setAttributeValueList(attributeValueList);
 		rangeKeyCondition.setComparisonOperator(ComparisonOperator.BETWEEN);
 		request.setRangeKeyCondition(rangeKeyCondition);
-		QueryResult result = client.query(request);
-		Assert.assertNotNull(result);
+		QueryResult result = getClient().query(request);
+		Assert.assertNotNull("Null result.", result);
+		Assert.assertNotNull("No items returned.", result.getItems());
+        Assert.assertEquals("Should return two items.", 2, result.getItems().size());
 		for (Map<String, AttributeValue> item : result.getItems()) {
-			Assert.assertTrue((new Integer(item.get("date").getN())) <= 10 && (new Integer(item.get("date").getN())) >= 5);
+			Assert.assertTrue(
+                    (item.get("range").getS().compareTo("Range2") == 0)
+                    ||
+                    (item.get("range").getS().compareTo("Range3") == 0)
+                    );
 		}
 	}
 
 	@Test
+	public void queryWithHashKeyAndRangeKeyConditionBEGINSWITHTest() {
+        AttributeValue hashKey = setupTableWithSeveralItems();
+
+        QueryRequest request = new QueryRequest().withTableName(tableName).withHashKeyValue(hashKey);
+
+		Condition rangeKeyCondition = new Condition();
+		List<AttributeValue> attributeValueList = new ArrayList<AttributeValue>();
+		attributeValueList.add(new AttributeValue().withS("Range"));
+		rangeKeyCondition.setAttributeValueList(attributeValueList);
+		rangeKeyCondition.setComparisonOperator(ComparisonOperator.BEGINS_WITH);
+		request.setRangeKeyCondition(rangeKeyCondition);
+		QueryResult result = getClient().query(request);
+		Assert.assertNotNull("Null result.", result);
+		Assert.assertNotNull("No items returned.", result.getItems());
+        Assert.assertEquals("Should return four items.", 4, result.getItems().size());
+		for (Map<String, AttributeValue> item : result.getItems()) {
+			Assert.assertTrue(
+                    item.get("range").getS().startsWith("Range")
+                    );
+		}
+	}
+
+	@Test
+	public void queryWithHashKeyAndRangeKeyConditionCONTAINSTest() {
+        AttributeValue hashKey = setupTableWithSeveralItems();
+
+        QueryRequest request = new QueryRequest().withTableName(tableName).withHashKeyValue(hashKey);
+
+		Condition rangeKeyCondition = new Condition();
+		List<AttributeValue> attributeValueList = new ArrayList<AttributeValue>();
+		attributeValueList.add(new AttributeValue().withS("ange1"));
+		rangeKeyCondition.setAttributeValueList(attributeValueList);
+		rangeKeyCondition.setComparisonOperator(ComparisonOperator.CONTAINS);
+		request.setRangeKeyCondition(rangeKeyCondition);
+		QueryResult result = getClient().query(request);
+		Assert.assertNotNull("Null result.", result);
+		Assert.assertNotNull("No items returned.", result.getItems());
+        Assert.assertEquals("Should return two items.", 2, result.getItems().size());
+		for (Map<String, AttributeValue> item : result.getItems()) {
+			Assert.assertTrue(
+                    item.get("range").getS().contains("ange1")
+                    );
+		}
+	}
+
+    /*
+	@Test
 	public void queryWithHashKeyAndLimitTest() {
 		QueryRequest request = getBasicReq();
 		request.setLimit(1);
-		QueryResult result = client.query(request);
+		QueryResult result = getClient().query(request);
 		Assert.assertNotNull(result);
 		Assert.assertEquals(result.getCount().intValue(), 1);
 	}
@@ -208,7 +337,7 @@ public class AlternatorQueryTest extends AlternatorTest {
 	public void queryWithoutTableNameTest() {
 		QueryRequest request = getBasicReq();
 		request.setTableName(null);
-		QueryResult result = client.query(request);
+		QueryResult result = getClient().query(request);
 		Assert.assertNull(result.getItems());
 	}*/
 }

--- a/src/test/java/com/michelboudreau/test/AlternatorScanTest.java
+++ b/src/test/java/com/michelboudreau/test/AlternatorScanTest.java
@@ -37,7 +37,7 @@ public class AlternatorScanTest extends AlternatorTest {
     public void tearDown() throws Exception {
         DeleteTableRequest del = new DeleteTableRequest();
         del.setTableName("Testing");
-        client.deleteTable(del);
+        getClient().deleteTable(del);
     }
 
 
@@ -55,7 +55,7 @@ public class AlternatorScanTest extends AlternatorTest {
         Map<String, Condition> conditionMap = new HashMap<String, Condition>();
         conditionMap.put("range", rangeKeyCondition);
         request.setScanFilter(conditionMap);
-        ScanResult result = client.scan(request);
+        ScanResult result = getClient().scan(request);
         Assert.assertNotNull(result);
         Assert.assertNotNull(result.getItems());
         for (Map<String, AttributeValue> item : result.getItems()) {
@@ -75,7 +75,7 @@ public class AlternatorScanTest extends AlternatorTest {
         Map<String, Condition> conditionMap = new HashMap<String, Condition>();
         conditionMap.put("range", rangeKeyCondition);
         request.setScanFilter(conditionMap);
-        ScanResult result = client.scan(request);
+        ScanResult result = getClient().scan(request);
         Assert.assertNotNull(result);
         Assert.assertNotNull(result.getItems());
         Assert.assertEquals(result.getItems().size(),0);
@@ -94,7 +94,7 @@ public class AlternatorScanTest extends AlternatorTest {
         Map<String, Condition> conditionMap = new HashMap<String, Condition>();
         conditionMap.put("range", rangeKeyCondition);
         request.setScanFilter(conditionMap);
-        ScanResult result = client.scan(request);
+        ScanResult result = getClient().scan(request);
         Assert.assertNotNull(result);
         Assert.assertNotNull(result.getItems());
         for (Map<String, AttributeValue> item : result.getItems()) {
@@ -114,7 +114,7 @@ public class AlternatorScanTest extends AlternatorTest {
         Map<String, Condition> conditionMap = new HashMap<String, Condition>();
         conditionMap.put("range", rangeKeyCondition);
         request.setScanFilter(conditionMap);
-        ScanResult result = client.scan(request);
+        ScanResult result = getClient().scan(request);
         Assert.assertNotNull(result);
         Assert.assertNotNull(result.getItems());
         Assert.assertEquals(result.getItems().size(),0);
@@ -132,7 +132,7 @@ public class AlternatorScanTest extends AlternatorTest {
         Map<String, Condition> conditionMap = new HashMap<String, Condition>();
         conditionMap.put("range", rangeKeyCondition);
         request.setScanFilter(conditionMap);
-        ScanResult result = client.scan(request);
+        ScanResult result = getClient().scan(request);
         Assert.assertNotNull(result);
         Assert.assertNotNull(result.getItems());
 //        Assert.assertEquals(result.getItems().size(),0);
@@ -155,7 +155,7 @@ public class AlternatorScanTest extends AlternatorTest {
         Map<String, Condition> conditionMap = new HashMap<String, Condition>();
         conditionMap.put("range", rangeKeyCondition);
         request.setScanFilter(conditionMap);
-        ScanResult result = client.scan(request);
+        ScanResult result = getClient().scan(request);
         Assert.assertNotNull(result);
         Assert.assertNotNull(result.getItems());
         for (Map<String, AttributeValue> item : result.getItems()) {
@@ -175,7 +175,7 @@ public class AlternatorScanTest extends AlternatorTest {
         Map<String, Condition> conditionMap = new HashMap<String, Condition>();
         conditionMap.put("range", rangeKeyCondition);
         request.setScanFilter(conditionMap);
-        ScanResult result = client.scan(request);
+        ScanResult result = getClient().scan(request);
         Assert.assertNotNull(result);
         Assert.assertNotNull(result.getItems());
         for (Map<String, AttributeValue> item : result.getItems()) {
@@ -199,7 +199,7 @@ public class AlternatorScanTest extends AlternatorTest {
         Map<String, Condition> conditionMap = new HashMap<String, Condition>();
         conditionMap.put("range", rangeKeyCondition);
         request.setScanFilter(conditionMap);
-        ScanResult result = client.scan(request);
+        ScanResult result = getClient().scan(request);
         Assert.assertNotNull(result);
         Assert.assertNotNull(result.getItems());
         for (Map<String, AttributeValue> item : result.getItems()) {
@@ -222,7 +222,7 @@ public class AlternatorScanTest extends AlternatorTest {
         conditionMap.put("range", rangeKeyCondition);
         request.setScanFilter(conditionMap);
 
-        ScanResult result = client.scan(request);
+        ScanResult result = getClient().scan(request);
         Assert.assertNotNull(result);
         Assert.assertNotNull(result.getItems());
 //        Assert.assertEquals(result.getItems().size(), 0);
@@ -242,7 +242,7 @@ public class AlternatorScanTest extends AlternatorTest {
 //                    .withLimit(10)
 //                    .withExclusiveStartKey(lastKeyEvaluated);
 //
-//            ScanResult result = client.scan(scanRequest);
+//            ScanResult result = getClient().scan(scanRequest);
 //            for (Map<String, AttributeValue> item : result.getItems()) {
 //                Assert.assertNotNull(result.getLastEvaluatedKey());
 //            }
@@ -255,7 +255,7 @@ public class AlternatorScanTest extends AlternatorTest {
 //    public void scanWithoutTableNameTest() {
 //        ScanRequest request = getBasicReq();
 //        request.setTableName(null);
-//        ScanResult result = client.scan(request);
+//        ScanResult result = getClient().scan(request);
 //        Assert.assertNull(result.getItems());
 //    }
 
@@ -264,7 +264,7 @@ public class AlternatorScanTest extends AlternatorTest {
     @Test
     public void basicScanTest() {
         ScanRequest scanRequest = getBasicReq();
-        ScanResult result = client.scan(scanRequest);
+        ScanResult result = getClient().scan(scanRequest);
         Assert.assertNotNull(result);
         Assert.assertNotNull(result.getCount());
         Assert.assertTrue(result.getCount().intValue() > 1);
@@ -274,7 +274,7 @@ public class AlternatorScanTest extends AlternatorTest {
     public void scanWithLimitTest() {
         ScanRequest scanRequest = getBasicReq();
         scanRequest.setLimit(5);
-        ScanResult result = client.scan(scanRequest);
+        ScanResult result = getClient().scan(scanRequest);
         Assert.assertNotNull(result);
         Assert.assertTrue(result.getCount().intValue() > 1 && result.getCount().intValue() <= 5);
     }
@@ -287,7 +287,7 @@ public class AlternatorScanTest extends AlternatorTest {
         attrToGet.add("date");
         attrToGet.add("testfield");
         request.setAttributesToGet(attrToGet);
-        ScanResult result = client.scan(request);
+        ScanResult result = getClient().scan(request);
         Assert.assertNotNull(result);
         for (Map<String, AttributeValue> item : result.getItems()) {
             Assert.assertFalse(item.containsKey("id"));
@@ -306,7 +306,7 @@ public class AlternatorScanTest extends AlternatorTest {
         AttributeValue hash = createStringAttribute();
         Map<String, AttributeValue> item = createGenericItem(hash);
         PutItemRequest req = new PutItemRequest().withTableName(tableName).withItem(item);
-        client.putItem(req);
+        getClient().putItem(req);
         return hash;
     }
 
@@ -314,7 +314,7 @@ public class AlternatorScanTest extends AlternatorTest {
         AttributeValue hash = createStringAttribute();
         Map<String, AttributeValue> item = createGenericItem(hash, rangeKey);
         PutItemRequest req = new PutItemRequest().withTableName(tableName).withItem(item);
-        client.putItem(req);
+        getClient().putItem(req);
         return hash;
     }
 

--- a/src/test/java/com/michelboudreau/test/AlternatorTableTest.java
+++ b/src/test/java/com/michelboudreau/test/AlternatorTableTest.java
@@ -98,7 +98,7 @@ public class AlternatorTableTest extends AlternatorTest {
 	public void describeTable() {
 		String name = createTableName();
 		createTable(name);
-		DescribeTableResult res = client.describeTable(new DescribeTableRequest().withTableName(name));
+		DescribeTableResult res = getClient().describeTable(new DescribeTableRequest().withTableName(name));
 		Assert.assertNotNull(res.getTable());
 		Assert.assertEquals(res.getTable().getTableName(), name);
 	}
@@ -106,7 +106,7 @@ public class AlternatorTableTest extends AlternatorTest {
 	@Test
 	public void describeTableWithoutTableName() {
 		createTable();
-		DescribeTableResult res = client.describeTable(new DescribeTableRequest());
+		DescribeTableResult res = getClient().describeTable(new DescribeTableRequest());
 		Assert.assertNull(res.getTable());
 	}
 
@@ -114,7 +114,7 @@ public class AlternatorTableTest extends AlternatorTest {
 	public void listTables() {
 		String name = createTableName();
 		createTable(name);
-		ListTablesResult res = client.listTables();
+		ListTablesResult res = getClient().listTables();
 		Assert.assertTrue(res.getTableNames().contains(name));
 	}
 
@@ -122,7 +122,7 @@ public class AlternatorTableTest extends AlternatorTest {
 	public void listTablesWithLimitOverTableCount() {
 		String name = createTableName();
 		createTable(name);
-		ListTablesResult res = client.listTables(new ListTablesRequest().withLimit(5));
+		ListTablesResult res = getClient().listTables(new ListTablesRequest().withLimit(5));
 		Assert.assertTrue(res.getTableNames().contains(name));
 		Assert.assertTrue(res.getTableNames().size() == 1);
 	}
@@ -133,7 +133,7 @@ public class AlternatorTableTest extends AlternatorTest {
 		createTable();
 		createTable(name);
 		createTable();
-		ListTablesResult res = client.listTables(new ListTablesRequest().withLimit(2));
+		ListTablesResult res = getClient().listTables(new ListTablesRequest().withLimit(2));
 		Assert.assertTrue(res.getTableNames().contains(name));
 		Assert.assertTrue(res.getTableNames().size() == 2);
 	}
@@ -144,7 +144,7 @@ public class AlternatorTableTest extends AlternatorTest {
 		createTable();
 		createTable();
 		createTable(name);
-		ListTablesResult res = client.listTables(new ListTablesRequest().withExclusiveStartTableName(name));
+		ListTablesResult res = getClient().listTables(new ListTablesRequest().withExclusiveStartTableName(name));
 		Assert.assertTrue(res.getTableNames().contains(name));
 		Assert.assertTrue(res.getTableNames().size() == 1);
 	}
@@ -157,7 +157,7 @@ public class AlternatorTableTest extends AlternatorTest {
 		createTable(name);
 		createTable();
 		createTable();
-		ListTablesResult res = client.listTables(new ListTablesRequest().withLimit(1).withExclusiveStartTableName(name));
+		ListTablesResult res = getClient().listTables(new ListTablesRequest().withLimit(1).withExclusiveStartTableName(name));
 		Assert.assertTrue(res.getTableNames().contains(name));
 		Assert.assertTrue(res.getTableNames().size() == 1);
 	}
@@ -170,7 +170,7 @@ public class AlternatorTableTest extends AlternatorTest {
 		createTable();
 		createTable();
 		createTable();
-		ListTablesResult res = client.listTables(new ListTablesRequest().withLimit(10).withExclusiveStartTableName(name));
+		ListTablesResult res = getClient().listTables(new ListTablesRequest().withLimit(10).withExclusiveStartTableName(name));
 		Assert.assertTrue(res.getTableNames().contains(name));
 		Assert.assertTrue(res.getTableNames().size() == 4);
 	}
@@ -179,8 +179,8 @@ public class AlternatorTableTest extends AlternatorTest {
 	public void deleteTableTest() {
 		String name = createTableName();
 		createTable(name);
-		client.deleteTable(new DeleteTableRequest(name));
-		ListTablesResult res = client.listTables();
+		getClient().deleteTable(new DeleteTableRequest(name));
+		ListTablesResult res = getClient().listTables();
 		Assert.assertFalse(res.getTableNames().contains(name));
 		Assert.assertTrue(res.getTableNames().size() == 0);
 	}
@@ -189,9 +189,9 @@ public class AlternatorTableTest extends AlternatorTest {
 	public void deleteTableWithoutName() {
 		String name = createTableName();
 		createTable(name);
-		DeleteTableResult res = client.deleteTable(new DeleteTableRequest());
+		DeleteTableResult res = getClient().deleteTable(new DeleteTableRequest());
 		Assert.assertNull(res.getTableDescription());
-		Assert.assertTrue(client.listTables().getTableNames().contains(name));
+		Assert.assertTrue(getClient().listTables().getTableNames().contains(name));
 	}
 
 	@Test
@@ -201,7 +201,7 @@ public class AlternatorTableTest extends AlternatorTest {
 		ProvisionedThroughput throughput = new ProvisionedThroughput().withReadCapacityUnits(50L).withWriteCapacityUnits(50L);
 		UpdateTableRequest req = new UpdateTableRequest().withTableName(name).withProvisionedThroughput(throughput);
 		Date date = new Date();
-		TableDescription desc = client.updateTable(req).getTableDescription();
+		TableDescription desc = getClient().updateTable(req).getTableDescription();
 		Assert.assertNotNull(desc);
 		Assert.assertEquals(name, desc.getTableName());
 		Assert.assertEquals(Math.round(date.getTime() / 1000), Math.round(desc.getProvisionedThroughput().getLastDecreaseDateTime().getTime() / 1000));
@@ -213,7 +213,7 @@ public class AlternatorTableTest extends AlternatorTest {
 		createTable();
 		ProvisionedThroughput throughput = new ProvisionedThroughput().withReadCapacityUnits(50L).withWriteCapacityUnits(50L);
 		UpdateTableRequest req = new UpdateTableRequest().withProvisionedThroughput(throughput);
-		Assert.assertNull(client.updateTable(req).getTableDescription());
+		Assert.assertNull(getClient().updateTable(req).getTableDescription());
 	}
 
 	@Test
@@ -221,12 +221,12 @@ public class AlternatorTableTest extends AlternatorTest {
 		String name = createTableName();
 		createTable(name);
 		UpdateTableRequest req = new UpdateTableRequest().withTableName(name);
-		Assert.assertNull(client.updateTable(req).getTableDescription());
+		Assert.assertNull(getClient().updateTable(req).getTableDescription());
 	}
 
 	@Test
 	public void updateTableWithoutNameOrThroughput() {
 		createTable();
-		Assert.assertNull(client.updateTable(new UpdateTableRequest()).getTableDescription());
+		Assert.assertNull(getClient().updateTable(new UpdateTableRequest()).getTableDescription());
 	}
 }

--- a/src/test/java/com/michelboudreau/test/AlternatorTest.java
+++ b/src/test/java/com/michelboudreau/test/AlternatorTest.java
@@ -1,20 +1,32 @@
 package com.michelboudreau.test;
 
+import com.amazonaws.services.dynamodb.AmazonDynamoDB;
 import com.amazonaws.services.dynamodb.datamodeling.DynamoDBMapper;
 import com.amazonaws.services.dynamodb.model.*;
 import com.michelboudreau.alternator.AlternatorDB;
 import com.michelboudreau.alternator.AlternatorDBClient;
+import com.michelboudreau.alternator.AlternatorDBInProcessClient;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.UUID;
-
 public class AlternatorTest {
+    /**
+     * Set to true to run AlternatorDBHandler as a separate Jetty service process.
+     * Set to false to invoke AlternatorDBHandler methods in-process
+     * to facilitate breakpoint debugging.
+     */
+    private static final boolean RUN_DB_AS_SERVICE = true;
+
 	static protected AlternatorDBClient client;
 	static protected DynamoDBMapper mapper;
+
+    static protected AlternatorDBInProcessClient inProcessClient;
+    static protected DynamoDBMapper inProcessMapper;
+
 	static protected AlternatorDB db;
 
 	private ProvisionedThroughput provisionedThroughput;
@@ -27,23 +39,49 @@ public class AlternatorTest {
 
 	@BeforeClass
 	public static void setUpOnce() throws Exception {
-		db = new AlternatorDB().start();
+        if (RUN_DB_AS_SERVICE) {
+            db = new AlternatorDB().start();
+        }
 	}
 
 	@AfterClass
 	public static void tearDownOnce() throws Exception {
-		db.stop();
+        if (db != null) {
+            db.stop();
+        }
 	}
+
+    @Autowired
+    public void setMapper(DynamoDBMapper value) {
+        mapper = value;
+    }
 
 	@Autowired
 	public void setClient(AlternatorDBClient value) {
 		client = value;
 	}
 
-	@Autowired
-	public void setMapper(DynamoDBMapper value) {
-		mapper = value;
-	}
+    protected AmazonDynamoDB getClient() {
+        if (RUN_DB_AS_SERVICE) {
+            return client;
+        } else {
+            if (inProcessClient == null) {
+                inProcessClient = new AlternatorDBInProcessClient();
+            }
+            return inProcessClient;
+        }
+    }
+
+    protected DynamoDBMapper getMapper() {
+        if (RUN_DB_AS_SERVICE) {
+            return mapper;
+        } else {
+            if (inProcessMapper == null) {
+                inProcessMapper = new DynamoDBMapper(getClient());
+            }
+            return inProcessMapper;
+        }
+    }
 
 	protected KeySchemaElement createStringKeyElement() {
 		KeySchemaElement el = new KeySchemaElement();
@@ -93,15 +131,15 @@ public class AlternatorTest {
 	}
 
 	protected TableDescription createTable(String name, KeySchema schema, ProvisionedThroughput throughput) {
-		return client.createTable(new CreateTableRequest(name, schema).withProvisionedThroughput(throughput)).getTableDescription();
+		return getClient().createTable(new CreateTableRequest(name, schema).withProvisionedThroughput(throughput)).getTableDescription();
 	}
 
 	protected void deleteAllTables() {
 		String lastTableName = null;
 		while (true) {
-			ListTablesResult res = client.listTables(new ListTablesRequest().withExclusiveStartTableName(lastTableName));
+			ListTablesResult res = getClient().listTables(new ListTablesRequest().withExclusiveStartTableName(lastTableName));
 			for (String tableName : res.getTableNames()) {
-				client.deleteTable(new DeleteTableRequest(tableName));
+				getClient().deleteTable(new DeleteTableRequest(tableName));
 			}
 			lastTableName = res.getLastEvaluatedTableName();
 			if (lastTableName == null) {
@@ -112,6 +150,10 @@ public class AlternatorTest {
 
 	protected AttributeValue createStringAttribute() {
 		return new AttributeValue(UUID.randomUUID().toString());
+	}
+
+	protected AttributeValue createStringAttribute(String value) {
+		return new AttributeValue(value);
 	}
 
 	protected AttributeValue createNumberAttribute() {
@@ -135,13 +177,39 @@ public class AlternatorTest {
 		return map;
 	}
 
+	protected Map<String, AttributeValue> createGenericItem(
+            AttributeValue hash,
+            AttributeValue range,
+            String attrName, String attrValue) {
+        return createGenericItem(hash, range, attrName, attrValue, null, null);
+	}
+
+	protected Map<String, AttributeValue> createGenericItem(
+            AttributeValue hash,
+            AttributeValue range,
+            String attrName1, String attrValue1,
+            String attrName2, String attrValue2) {
+		Map<String, AttributeValue> map = new HashMap<String, AttributeValue>();
+		map.put("id", hash);
+		if(range != null) {
+			map.put("range", range);
+		}
+		if((attrName1 != null) && (attrValue1 != null)) {
+			map.put(attrName1, createStringAttribute(attrValue1));
+		}
+		if((attrName2 != null) && (attrValue2 != null)) {
+			map.put(attrName2, createStringAttribute(attrValue2));
+		}
+		return map;
+	}
+
     protected AttributeValue createItem(String tableName){
         KeySchema schema = new KeySchema(new KeySchemaElement().withAttributeName("id").withAttributeType(ScalarAttributeType.S));
         createTable(tableName, schema);
         AttributeValue hash = createStringAttribute();
         Map<String, AttributeValue> item = createGenericItem(hash);
         PutItemRequest req = new PutItemRequest().withTableName(tableName).withItem(item);
-        client.putItem(req);
+        getClient().putItem(req);
         return hash;
     }
 }

--- a/src/test/java/com/michelboudreau/test/AlternatorTestSuite.java
+++ b/src/test/java/com/michelboudreau/test/AlternatorTestSuite.java
@@ -5,6 +5,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
 @RunWith(Suite.class)
-@Suite.SuiteClasses({ AlternatorTableTest.class , AlternatorItemTest.class , AlternatorQueryTest.class, AlternatorScanTest.class})
+@Suite.SuiteClasses({ AlternatorTableTest.class , AlternatorItemTest.class , AlternatorQueryTest.class, AlternatorScanTest.class, AlternatorBatchItemTest.class})
 public class AlternatorTestSuite {
 }


### PR DESCRIPTION
Added support for multiple items with different Range Key values for a single Hash Key value.

This involved replacing the Table.items collection with Table.itemRangeGroups.
Each entry in this collection holds one or more items that share the same Hash Key value.

  old: private Map&lt;String, Map&lt;String, AttributeValue&gt;&gt; items = new HashMap&lt;String, Map&lt;String, AttributeValue&gt;&gt;();
  new: private Map&lt;String, ItemRangeGroup&gt; itemRangeGroups = new HashMap&lt;String, ItemRangeGroup&gt;();

ItemRangeGroup is a new model class with an items collection that contains all the items in a table with the same Hash Key value.

  private SortedMap&lt;String, Map&lt;String, AttributeValue&gt;&gt; items = new TreeMap&lt;String, Map&lt;String, AttributeValue&gt;&gt;();

The Range Key value is used as the index into a sorted collection.
This allows queries to return the items in Range Key order as described by the DynamoDB documentation.
If a table has no Range Key defined for its schema, an empty String is used as the TreeMap index.

Various AlternatorDBHandler methods were revised to add awareness of this "nested collection" for the items.
Any iteration that previously scanned the Table.items collection was converted to a nested loop
for the Table.itemRangeGroups and then each itemRangeGroup.items value.

The AlternatorDBHandler.query method now supports RangeKeyCondition queries.
The ItemRangeGroup.getItems method will filter its returned item list when passed a non-null rangeKeyCondition argument.

The following statement was added to the AlternatorDBHandler.query method to avoid an infinite paging loop 
when accessed via the DynamoDBMapper:

  queryResult.setLastEvaluatedKey(null)

A new AlternatorDBInProcessClient variant of AlternatorDBClient bypasses the cross-process Jetty service call
and instead directly invokes the AlternatorDBHandler methods.
This allows breakpoints within AlternatorDBHandler to debug the logic when invoked by unit tests.

To activate the AlternatorDBInProcessClient for the unit tests, change the value of this constant to false
within AlternatorTest:

  private static final boolean RUN_DB_AS_SERVICE = true;

In order to support this option, all unit tests had "client." references changed to "getClient()."

Questions on this update can be addressed to Rick Rutt (RRutt@Live.com)
