### PR TITLE
Minor bug fix for .scan with limit higher than result set size.

### DIFF
--- a/src/main/java/com/michelboudreau/alternator/AlternatorDBHandler.java
+++ b/src/main/java/com/michelboudreau/alternator/AlternatorDBHandler.java
@@ -629,7 +629,7 @@ class AlternatorDBHandler {
 			}
           }
 		}
-		if (request.getLimit() != null) {
+		if ((request.getLimit() != null) && (items.size() > request.getLimit())) {
 			items = items.subList(0, request.getLimit() - 1);
 		}
 

--- a/src/test/java/com/michelboudreau/test/AlternatorScanTest.java
+++ b/src/test/java/com/michelboudreau/test/AlternatorScanTest.java
@@ -122,6 +122,57 @@ public class AlternatorScanTest extends AlternatorTest {
 
 
     @Test
+    public void scanWithScanFilterGTTestWithLowLimit() {
+        final int limit = 5;
+                
+        ScanRequest request = getBasicReq();
+        Condition rangeKeyCondition = new Condition();
+        List<AttributeValue> attributeValueList = new ArrayList<AttributeValue>();
+//
+        attributeValueList.add(new AttributeValue().withN("50"));
+        rangeKeyCondition.setAttributeValueList(attributeValueList);
+        rangeKeyCondition.setComparisonOperator(ComparisonOperator.GT);
+        Map<String, Condition> conditionMap = new HashMap<String, Condition>();
+        conditionMap.put("range", rangeKeyCondition);
+        request.setScanFilter(conditionMap);
+        request.setLimit(limit);
+        ScanResult result = getClient().scan(request);
+        Assert.assertNotNull(result);
+        Assert.assertNotNull(result.getItems());
+        int itemCount = result.getItems().size();
+        Assert.assertTrue(itemCount <= limit);
+        for (Map<String, AttributeValue> item : result.getItems()) {
+            Assert.assertTrue(new Integer(item.get("range").getN()) > new Integer(new AttributeValue().withN("50").getN()));
+        }
+    }
+
+    @Test
+    public void scanWithScanFilterGTTestWithHighLimit() {
+        final int limit = 1000;
+                
+        ScanRequest request = getBasicReq();
+        Condition rangeKeyCondition = new Condition();
+        List<AttributeValue> attributeValueList = new ArrayList<AttributeValue>();
+//
+        attributeValueList.add(new AttributeValue().withN("50"));
+        rangeKeyCondition.setAttributeValueList(attributeValueList);
+        rangeKeyCondition.setComparisonOperator(ComparisonOperator.GT);
+        Map<String, Condition> conditionMap = new HashMap<String, Condition>();
+        conditionMap.put("range", rangeKeyCondition);
+        request.setScanFilter(conditionMap);
+        request.setLimit(limit);
+        ScanResult result = getClient().scan(request);
+        Assert.assertNotNull(result);
+        Assert.assertNotNull(result.getItems());
+        int itemCount = result.getItems().size();
+        Assert.assertTrue(itemCount <= limit);
+        for (Map<String, AttributeValue> item : result.getItems()) {
+            Assert.assertTrue(new Integer(item.get("range").getN()) > new Integer(new AttributeValue().withN("50").getN()));
+        }
+    }
+
+
+    @Test
     public void scanWithScanFilterGETest() { //Greater or Equal
         ScanRequest request = getBasicReq();
         Condition rangeKeyCondition = new Condition();


### PR DESCRIPTION
If a limit is passed in a scan request, and the limit is larger than the number of items that meet the scan criteria, a bounds exception was thrown by the .subList method.

This fix checks the limit vs. the original items.size() to determine if .subList is required.

Two additional unit tests were added to exercise both "low" and "high" limits.
The "high" limit was the one that previously triggered an exception.
