### PR TITLE
Add support for Limit for Mapper + bump AWS SDK version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 		<spring.framework.version>3.1.2.RELEASE</spring.framework.version>
 		<spring.security.version>3.1.0.M1</spring.security.version>
 		<slf4j.version>1.7.0</slf4j.version>
-		<aws.version>1.3.21</aws.version>
+		<aws.version>1.3.33</aws.version>
 		<jetty.version>7.6.3.v20120416</jetty.version>
 	</properties>
 

--- a/src/main/java/com/amazonaws/services/dynamodb/model/transform/ConditionJsonUnmarshaller.java
+++ b/src/main/java/com/amazonaws/services/dynamodb/model/transform/ConditionJsonUnmarshaller.java
@@ -1,8 +1,13 @@
 package com.amazonaws.services.dynamodb.model.transform;
 
-import com.amazonaws.transform.*;
 import org.codehaus.jackson.JsonToken;
-import com.amazonaws.services.dynamodb.model.*;
+
+import com.amazonaws.services.dynamodb.model.AttributeValue;
+import com.amazonaws.services.dynamodb.model.Condition;
+import com.amazonaws.transform.JsonUnmarshallerContext;
+import com.amazonaws.transform.ListUnmarshaller;
+import com.amazonaws.transform.SimpleTypeJsonUnmarshallers;
+import com.amazonaws.transform.Unmarshaller;
 
 
 public class ConditionJsonUnmarshaller implements Unmarshaller<Condition, JsonUnmarshallerContext> {
@@ -22,7 +27,7 @@ public class ConditionJsonUnmarshaller implements Unmarshaller<Condition, JsonUn
                 if (context.testExpression("AttributeValueList", targetDepth)) {
                     request.setAttributeValueList(new ListUnmarshaller<AttributeValue>(AttributeValueJsonUnmarshaller.getInstance()).unmarshall(context));
                 }
-                if (context.testExpression("ComparisonOperator", originalDepth) || context.testExpression("ComparisonOperator", originalDepth-1)) {
+				if (context.testExpression("ComparisonOperator", targetDepth) || context.testExpression("ComparisonOperator", targetDepth - 1)) {
                     context.nextToken();
                     request.setComparisonOperator(SimpleTypeJsonUnmarshallers.StringJsonUnmarshaller.getInstance().unmarshall(context));
                 }

--- a/src/main/java/com/michelboudreau/alternator/AlternatorDBAsyncClient.java
+++ b/src/main/java/com/michelboudreau/alternator/AlternatorDBAsyncClient.java
@@ -7,6 +7,7 @@ import java.util.concurrent.TimeoutException;
 
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.AmazonServiceException;
+import com.amazonaws.handlers.AsyncHandler;
 import com.amazonaws.services.dynamodb.AmazonDynamoDBAsync;
 import com.amazonaws.services.dynamodb.model.BatchGetItemRequest;
 import com.amazonaws.services.dynamodb.model.BatchGetItemResult;
@@ -132,5 +133,70 @@ public class AlternatorDBAsyncClient extends AlternatorDBClient implements Amazo
 		public boolean isDone() {
 			return true;
 		}
+	}
+
+	@Override
+	public Future<ListTablesResult> listTablesAsync(ListTablesRequest listTablesRequest, AsyncHandler<ListTablesRequest, ListTablesResult> asyncHandler) throws AmazonServiceException, AmazonClientException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Future<QueryResult> queryAsync(QueryRequest queryRequest, AsyncHandler<QueryRequest, QueryResult> asyncHandler) throws AmazonServiceException, AmazonClientException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Future<BatchWriteItemResult> batchWriteItemAsync(BatchWriteItemRequest batchWriteItemRequest, AsyncHandler<BatchWriteItemRequest, BatchWriteItemResult> asyncHandler) throws AmazonServiceException, AmazonClientException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Future<UpdateItemResult> updateItemAsync(UpdateItemRequest updateItemRequest, AsyncHandler<UpdateItemRequest, UpdateItemResult> asyncHandler) throws AmazonServiceException, AmazonClientException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Future<PutItemResult> putItemAsync(PutItemRequest putItemRequest, AsyncHandler<PutItemRequest, PutItemResult> asyncHandler) throws AmazonServiceException, AmazonClientException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Future<DescribeTableResult> describeTableAsync(DescribeTableRequest describeTableRequest, AsyncHandler<DescribeTableRequest, DescribeTableResult> asyncHandler) throws AmazonServiceException, AmazonClientException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Future<ScanResult> scanAsync(ScanRequest scanRequest, AsyncHandler<ScanRequest, ScanResult> asyncHandler) throws AmazonServiceException, AmazonClientException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Future<CreateTableResult> createTableAsync(CreateTableRequest createTableRequest, AsyncHandler<CreateTableRequest, CreateTableResult> asyncHandler) throws AmazonServiceException, AmazonClientException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Future<UpdateTableResult> updateTableAsync(UpdateTableRequest updateTableRequest, AsyncHandler<UpdateTableRequest, UpdateTableResult> asyncHandler) throws AmazonServiceException, AmazonClientException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Future<DeleteTableResult> deleteTableAsync(DeleteTableRequest deleteTableRequest, AsyncHandler<DeleteTableRequest, DeleteTableResult> asyncHandler) throws AmazonServiceException, AmazonClientException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Future<DeleteItemResult> deleteItemAsync(DeleteItemRequest deleteItemRequest, AsyncHandler<DeleteItemRequest, DeleteItemResult> asyncHandler) throws AmazonServiceException, AmazonClientException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Future<GetItemResult> getItemAsync(GetItemRequest getItemRequest, AsyncHandler<GetItemRequest, GetItemResult> asyncHandler) throws AmazonServiceException, AmazonClientException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Future<BatchGetItemResult> batchGetItemAsync(BatchGetItemRequest batchGetItemRequest, AsyncHandler<BatchGetItemRequest, BatchGetItemResult> asyncHandler) throws AmazonServiceException, AmazonClientException {
+		throw new UnsupportedOperationException();
 	}
 }

--- a/src/main/java/com/michelboudreau/alternator/AlternatorDBHandler.java
+++ b/src/main/java/com/michelboudreau/alternator/AlternatorDBHandler.java
@@ -760,16 +760,20 @@ class AlternatorDBHandler {
         KeySchemaElement rangeKeyElement = keySchema.getRangeKeyElement();
         ItemRangeGroup rangeGroup = table.getItemRangeGroup(hashKeyValue);
         if (rangeGroup != null) {
-            for (Map<String, AttributeValue> item : rangeGroup.getItems(rangeKeyElement, request.getRangeKeyCondition())) {
-				if (request.getLimit() == null || request.getLimit() <= 0 || list.size() < request.getLimit()) {
-					if (request.getScanIndexForward() == null || request.getScanIndexForward() == false) {
-						list.add(0, getItemWithAttributesToGet(item, attributesToGet));
-					} else {
-						list.add(getItemWithAttributesToGet(item, attributesToGet));
-					}
+			for (Map<String, AttributeValue> item : rangeGroup.getItems(rangeKeyElement, request.getRangeKeyCondition())) {
+				if (request.getScanIndexForward() == null || request.getScanIndexForward() == false) {
+					list.add(0, getItemWithAttributesToGet(item, attributesToGet));
+				} else {
+					list.add(getItemWithAttributesToGet(item, attributesToGet));
 				}
             }
         }
+
+		if (request.getLimit() != null && request.getLimit() > 0) {
+			while (list.size() > request.getLimit()) {
+				list.remove((int) request.getLimit());
+			}
+		}
 
 
 		queryResult.setItems(list);

--- a/src/test/java/com/michelboudreau/test/AlternatorMapperTest.java
+++ b/src/test/java/com/michelboudreau/test/AlternatorMapperTest.java
@@ -409,4 +409,22 @@ public class AlternatorMapperTest extends AlternatorTest
 		TestClassWithHashRangeKey res = mapper.query(TestClassWithHashRangeKey.class, new DynamoDBQueryExpression(new AttributeValue("code")).withScanIndexForward(false).withLimit(1)).get(0);
 		Assert.assertEquals("second", res.getStringData());
 	}
+
+	@Test
+	public void limitTest() {
+		KeySchema schema = new KeySchema(new KeySchemaElement().withAttributeName("hashCode").withAttributeType(ScalarAttributeType.S));
+		schema.setRangeKeyElement(new KeySchemaElement().withAttributeName("rangeCode").withAttributeType(ScalarAttributeType.S));
+		createTable(hashRangeTableName, schema);
+
+		for (int i = 0; i < 10; i++) {
+			TestClassWithHashRangeKey c = new TestClassWithHashRangeKey();
+			c.setHashCode("code");
+			c.setRangeCode(i + "");
+			mapper.save(c);
+		}
+
+		Assert.assertEquals(1, mapper.query(TestClassWithHashRangeKey.class, new DynamoDBQueryExpression(new AttributeValue("code")).withLimit(1)).size());
+		Assert.assertEquals(3, mapper.query(TestClassWithHashRangeKey.class, new DynamoDBQueryExpression(new AttributeValue("code")).withLimit(3)).size());
+		Assert.assertEquals(10, mapper.query(TestClassWithHashRangeKey.class, new DynamoDBQueryExpression(new AttributeValue("code")).withLimit(20)).size());
+	}
 }


### PR DESCRIPTION
Mapper now supports querys with Limit set, but it needs a more recent version of AWS SDK.  This required some fixes, but now all tests passes
