### PR TITLE
Bug fixes for BatchGetItem UnprocessedKeys and BatchWriteItem v2 Deletes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ target
 .classpath
 alternator*.db
 Alternator*.db
+nb-configuration.xml

--- a/src/main/java/com/amazonaws/services/dynamodb/model/transform/BatchGetItemResultMarshaller.java
+++ b/src/main/java/com/amazonaws/services/dynamodb/model/transform/BatchGetItemResultMarshaller.java
@@ -5,9 +5,9 @@ import com.amazonaws.AmazonClientException;
 import com.amazonaws.services.dynamodb.model.AttributeValue;
 import com.amazonaws.services.dynamodb.model.BatchGetItemResult;
 import com.amazonaws.services.dynamodb.model.BatchResponse;
+import com.amazonaws.services.dynamodb.model.KeysAndAttributes;
 import com.amazonaws.transform.Marshaller;
 import com.amazonaws.util.json.JSONWriter;
-
 import java.io.StringWriter;
 import java.util.List;
 import java.util.Map;
@@ -77,6 +77,25 @@ public class BatchGetItemResultMarshaller implements Marshaller<String, BatchGet
 			}
             //End response object
 			jsonWriter.endObject();
+
+            //Begin unprocessedKeys
+			jsonWriter.key("UnprocessedKeys").object();
+            Map<String, KeysAndAttributes> unprocessedKeys = batchGetItemResult.getUnprocessedKeys();
+            if (unprocessedKeys != null) {
+                for (String tableKey : unprocessedKeys.keySet()) {
+                    //begin table
+                    jsonWriter.key(tableKey).array();
+
+                    // NOTE: We are just emulating an empty set of unprocessed keys.
+
+                    //end table
+                    jsonWriter.endArray();
+                }
+            }
+
+            //End unprocessedKeys
+			jsonWriter.endObject();
+
             //End whole object containing both response and unprocessed keys!
 			jsonWriter.endObject();
 

--- a/src/main/java/com/amazonaws/services/dynamodbv2/model/transform/BatchGetItemResultMarshaller.java
+++ b/src/main/java/com/amazonaws/services/dynamodbv2/model/transform/BatchGetItemResultMarshaller.java
@@ -3,6 +3,7 @@ package com.amazonaws.services.dynamodbv2.model.transform;
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import com.amazonaws.services.dynamodbv2.model.BatchGetItemResult;
+import com.amazonaws.services.dynamodbv2.model.KeysAndAttributes;
 import com.amazonaws.transform.Marshaller;
 import com.amazonaws.util.json.JSONWriter;
 
@@ -71,6 +72,25 @@ public class BatchGetItemResultMarshaller implements Marshaller<String, BatchGet
 			}
             //End response object
 			jsonWriter.endObject();
+
+            //Begin unprocessedKeys
+			jsonWriter.key("UnprocessedKeys").object();
+            Map<String, KeysAndAttributes> unprocessedKeys = batchGetItemResult.getUnprocessedKeys();
+            if (unprocessedKeys != null) {
+                for (String tableKey : unprocessedKeys.keySet()) {
+                    //begin table
+                    jsonWriter.key(tableKey).array();
+
+                    // NOTE: We are just emulating an empty set of unprocessed keys.
+
+                    //end table
+                    jsonWriter.endArray();
+                }
+            }
+
+            //End unprocessedKeys
+			jsonWriter.endObject();
+
             //End whole object containing both response and unprocessed keys!
 			jsonWriter.endObject();
 

--- a/src/main/java/com/michelboudreau/alternator/AlternatorDBHandler.java
+++ b/src/main/java/com/michelboudreau/alternator/AlternatorDBHandler.java
@@ -693,6 +693,7 @@ public class AlternatorDBHandler {
 				batchGetItemResult.getResponses().put(tableName, batchResponse);
 			}
 		}
+        batchGetItemResult.setUnprocessedKeys(new HashMap<String, KeysAndAttributes>());
 		return batchGetItemResult;
 	}
 
@@ -730,6 +731,7 @@ public class AlternatorDBHandler {
 	}
 
 	public com.amazonaws.services.dynamodbv2.model.BatchWriteItemResult batchWriteItemV2(com.amazonaws.services.dynamodbv2.model.BatchWriteItemRequest v2Request) {
+     try {
 		com.amazonaws.services.dynamodbv2.model.BatchWriteItemResult batchWriteItemResult =
                 new com.amazonaws.services.dynamodbv2.model.BatchWriteItemResult();
         List<com.amazonaws.services.dynamodbv2.model.ConsumedCapacity> v2Capacities =
@@ -750,6 +752,7 @@ public class AlternatorDBHandler {
 				if (deleteRequest != null) {
                     com.amazonaws.services.dynamodbv2.model.DeleteItemRequest deleteItemRequest =
                         new com.amazonaws.services.dynamodbv2.model.DeleteItemRequest()
+                            .withTableName(tableName)
                             .withKey(deleteRequest.getKey())
                             ;
                     deleteItemV2(deleteItemRequest);
@@ -766,6 +769,9 @@ public class AlternatorDBHandler {
             );
         batchWriteItemResult.setConsumedCapacity(v2Capacities);
 		return batchWriteItemResult;
+      } catch (ResourceNotFoundException rnfe) {
+			throw new com.amazonaws.services.dynamodbv2.model.ResourceNotFoundException(rnfe.getMessage());
+      }
 	}
 
 	public synchronized ScanResult scan(ScanRequest request) {

--- a/src/test/java/com/michelboudreau/test/AlternatorBatchItemTest.java
+++ b/src/test/java/com/michelboudreau/test/AlternatorBatchItemTest.java
@@ -1,21 +1,17 @@
 package com.michelboudreau.test;
 
-import com.amazonaws.auth.AWSCredentials;
-import com.amazonaws.auth.PropertiesCredentials;
-import com.amazonaws.services.dynamodb.AmazonDynamoDBClient;
 import com.amazonaws.services.dynamodb.model.*;
-import junit.framework.Assert;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-
-import java.util.List;
-import java.util.Map;
-import java.util.HashMap;
-import java.util.ArrayList;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = {"classpath:/applicationContext.xml"})
@@ -88,7 +84,7 @@ public class AlternatorBatchItemTest extends AlternatorTest {
 
         batchGetItemRequest.withRequestItems(requestItems);
 		BatchGetItemResult result  = getClient().batchGetItem(batchGetItemRequest);
-
+        Assert.assertNotNull("UnprocessedKeys should be empty rather than null.", result.getUnprocessedKeys());
 	}
 
     @Test


### PR DESCRIPTION
This revision addresses these two Issues:

AlternatorDBHandler.batchWriteItemV2() - fails for delete items
https://github.com/mboudreau/Alternator/issues/69

BatchGetItems - UnprocessedKeys is Null
https://github.com/mboudreau/Alternator/issues/42
