### PR TITLE
Alternator 0.8.0-SNAPSHOT: Revise for version 1.6.11 of AWS SDK for Java.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
 	<groupId>com.michelboudreau</groupId>
 	<artifactId>alternator</artifactId>
-	<version>0.7.2-SNAPSHOT</version>
+	<version>0.8.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>Alternator</name>
@@ -22,7 +22,7 @@
 		<spring.framework.version>3.2.4.RELEASE</spring.framework.version>
 		<spring.security.version>3.1.0.M1</spring.security.version>
 		<slf4j.version>1.7.0</slf4j.version>
-		<aws.version>1.6.4</aws.version>
+		<aws.version>1.6.11</aws.version>
 		<jetty.version>8.1.12.v20130726</jetty.version>
 	</properties>
 
@@ -70,10 +70,10 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.5.1</version>
+				<version>3.1</version>
 				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
+					<source>1.5</source>
+					<target>1.5</target>
 					<showWarnings>true</showWarnings>
 					<showDeprecation>true</showDeprecation>
 				</configuration>
@@ -239,7 +239,7 @@
 			<version>2.2.2</version>
 		</dependency>
 	</dependencies>
-	
+
 	<profiles>
 		<profile>
 			<id>standalone</id>

--- a/src/main/java/com/michelboudreau/alternatorv2/AlternatorDBClientV2.java
+++ b/src/main/java/com/michelboudreau/alternatorv2/AlternatorDBClientV2.java
@@ -7,6 +7,7 @@ import com.amazonaws.AmazonWebServiceRequest;
 import com.amazonaws.AmazonWebServiceResponse;
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.Request;
+import com.amazonaws.Response;
 import com.amazonaws.ResponseMetadata;
 import com.amazonaws.handlers.HandlerChainFactory;
 import com.amazonaws.http.ExecutionContext;
@@ -14,10 +15,14 @@ import com.amazonaws.http.HttpResponseHandler;
 import com.amazonaws.http.JsonErrorResponseHandler;
 import com.amazonaws.http.JsonResponseHandler;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import com.amazonaws.services.dynamodbv2.model.AttributeDefinition;
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.amazonaws.services.dynamodbv2.model.AttributeValueUpdate;
 import com.amazonaws.services.dynamodbv2.model.BatchGetItemRequest;
 import com.amazonaws.services.dynamodbv2.model.BatchGetItemResult;
 import com.amazonaws.services.dynamodbv2.model.BatchWriteItemRequest;
 import com.amazonaws.services.dynamodbv2.model.BatchWriteItemResult;
+import com.amazonaws.services.dynamodbv2.model.Condition;
 import com.amazonaws.services.dynamodbv2.model.CreateTableRequest;
 import com.amazonaws.services.dynamodbv2.model.CreateTableResult;
 import com.amazonaws.services.dynamodbv2.model.DeleteItemRequest;
@@ -28,8 +33,11 @@ import com.amazonaws.services.dynamodbv2.model.DescribeTableRequest;
 import com.amazonaws.services.dynamodbv2.model.DescribeTableResult;
 import com.amazonaws.services.dynamodbv2.model.GetItemRequest;
 import com.amazonaws.services.dynamodbv2.model.GetItemResult;
+import com.amazonaws.services.dynamodbv2.model.KeySchemaElement;
+import com.amazonaws.services.dynamodbv2.model.KeysAndAttributes;
 import com.amazonaws.services.dynamodbv2.model.ListTablesRequest;
 import com.amazonaws.services.dynamodbv2.model.ListTablesResult;
+import com.amazonaws.services.dynamodbv2.model.ProvisionedThroughput;
 import com.amazonaws.services.dynamodbv2.model.PutItemRequest;
 import com.amazonaws.services.dynamodbv2.model.PutItemResult;
 import com.amazonaws.services.dynamodbv2.model.QueryRequest;
@@ -40,6 +48,7 @@ import com.amazonaws.services.dynamodbv2.model.UpdateItemRequest;
 import com.amazonaws.services.dynamodbv2.model.UpdateItemResult;
 import com.amazonaws.services.dynamodbv2.model.UpdateTableRequest;
 import com.amazonaws.services.dynamodbv2.model.UpdateTableResult;
+import com.amazonaws.services.dynamodbv2.model.WriteRequest;
 import com.amazonaws.services.dynamodbv2.model.transform.BatchGetItemRequestMarshaller;
 import com.amazonaws.services.dynamodbv2.model.transform.BatchGetItemResultJsonUnmarshaller;
 import com.amazonaws.services.dynamodbv2.model.transform.BatchWriteItemRequestMarshaller;
@@ -109,11 +118,10 @@ public class AlternatorDBClientV2 extends AmazonWebServiceClient implements Amaz
 		setEndpoint("http://localhost:9090/");
 
 		HandlerChainFactory chainFactory = new HandlerChainFactory();
-		requestHandlers.addAll(chainFactory.newRequestHandlerChain("/com/amazonaws/services/dynamodb/request.handlers"));
-
+		requestHandler2s.addAll(chainFactory.newRequestHandlerChain("/com/amazonaws/services/dynamodb/request.handlers"));
 
 		clientConfiguration = new ClientConfiguration(clientConfiguration);
-		if (clientConfiguration.getMaxErrorRetry() == ClientConfiguration.DEFAULT_MAX_RETRIES) {
+		if (clientConfiguration.getRetryPolicy() == ClientConfiguration.DEFAULT_RETRY_POLICY) {
 			log.debug("Overriding default max error retry value to: " + 10);
 			clientConfiguration.setMaxErrorRetry(10);
 		}
@@ -151,7 +159,14 @@ public class AlternatorDBClientV2 extends AmazonWebServiceClient implements Amaz
 		JsonResponseHandler<BatchWriteItemResult> responseHandler = new JsonResponseHandler<BatchWriteItemResult>(unmarshaller);
 
 		return invoke(request, responseHandler);
-}
+    }
+
+    @Override
+        public BatchWriteItemResult batchWriteItem(java.util.Map<String,java.util.List<WriteRequest>> requestItems)
+                 throws AmazonServiceException, AmazonClientException {
+
+                 throw new AmazonClientException("batchWriteItem using Map is not implemented in Alternator.");
+        }
 
     @Override
 	public UpdateItemResult updateItem(UpdateItemRequest updateItemRequest)
@@ -165,6 +180,20 @@ public class AlternatorDBClientV2 extends AmazonWebServiceClient implements Amaz
 	}
 
     @Override
+        public UpdateItemResult updateItem(String tableName, java.util.Map<String, AttributeValue> key, java.util.Map<String, AttributeValueUpdate> attributeUpdates, String returnValues)
+                 throws AmazonServiceException, AmazonClientException {
+
+                 throw new AmazonClientException("updateItem using String, Map, Map, and String is not implemented in Alternator.");
+        }
+
+    @Override
+        public UpdateItemResult updateItem(String tableName, java.util.Map<String,AttributeValue> key, java.util.Map<String,AttributeValueUpdate> attributeUpdates)
+                 throws AmazonServiceException, AmazonClientException {
+
+                 throw new AmazonClientException("updateItem using String, Map, and Map is not implemented in Alternator.");
+        }
+
+    @Override
 	public PutItemResult putItem(PutItemRequest putItemRequest)
 			throws AmazonServiceException, AmazonClientException {
 		Request<PutItemRequest> request = new PutItemRequestMarshaller().marshall(putItemRequest);
@@ -174,6 +203,20 @@ public class AlternatorDBClientV2 extends AmazonWebServiceClient implements Amaz
 
 		return invoke(request, responseHandler);
 	}
+
+    @Override
+        public PutItemResult putItem(String tableName, java.util.Map<String,AttributeValue> item, String returnValues)
+                 throws AmazonServiceException, AmazonClientException {
+
+                 throw new AmazonClientException("putItem using String, Map, and String is not implemented in Alternator.");
+        }
+
+    @Override
+        public PutItemResult putItem(String tableName, java.util.Map<String,AttributeValue> item)
+                 throws AmazonServiceException, AmazonClientException {
+
+                 throw new AmazonClientException("putItem using String and Map is not implemented in Alternator.");
+        }
 
     @Override
 	public DescribeTableResult describeTable(DescribeTableRequest describeTableRequest)
@@ -187,6 +230,13 @@ public class AlternatorDBClientV2 extends AmazonWebServiceClient implements Amaz
 	}
 
     @Override
+        public DescribeTableResult describeTable(String tableName)
+                 throws AmazonServiceException, AmazonClientException {
+
+                 throw new AmazonClientException("describeTable using String is not implemented in Alternator.");
+        }
+
+    @Override
 	public ScanResult scan(ScanRequest scanRequest)
 			throws AmazonServiceException, AmazonClientException {
 		Request<ScanRequest> request = new ScanRequestMarshaller().marshall(scanRequest);
@@ -196,6 +246,27 @@ public class AlternatorDBClientV2 extends AmazonWebServiceClient implements Amaz
 
 		return invoke(request, responseHandler);
 	}
+
+    @Override
+        public ScanResult scan(String tableName, java.util.List<String> attributesToGet, java.util.Map<String,Condition> scanFilter)
+                 throws AmazonServiceException, AmazonClientException {
+
+                 throw new AmazonClientException("scan using String, List, and Map is not implemented in Alternator.");
+        }
+
+    @Override
+        public ScanResult scan(String tableName, java.util.Map<String,Condition> scanFilter)
+                 throws AmazonServiceException, AmazonClientException {
+
+                 throw new AmazonClientException("scan using String and Map is not implemented in Alternator.");
+        }
+
+    @Override
+        public ScanResult scan(String tableName, java.util.List<String> attributesToGet)
+                 throws AmazonServiceException, AmazonClientException {
+
+                 throw new AmazonClientException("scan using String and List is not implemented in Alternator.");
+        }
 
     @Override
 	public CreateTableResult createTable(CreateTableRequest createTableRequest)
@@ -209,6 +280,13 @@ public class AlternatorDBClientV2 extends AmazonWebServiceClient implements Amaz
 	}
 
     @Override
+        public CreateTableResult createTable(java.util.List<AttributeDefinition> attributeDefinitions, String tableName, java.util.List<KeySchemaElement> keySchema, ProvisionedThroughput provisionedThroughput)
+                 throws AmazonServiceException, AmazonClientException {
+
+                 throw new AmazonClientException("createTable using List, String, List, and ProvisionedThroughput is not implemented in Alternator.");
+        }
+
+    @Override
 	public UpdateTableResult updateTable(UpdateTableRequest updateTableRequest)
 			throws AmazonServiceException, AmazonClientException {
 		Request<UpdateTableRequest> request = new UpdateTableRequestMarshaller().marshall(updateTableRequest);
@@ -218,6 +296,13 @@ public class AlternatorDBClientV2 extends AmazonWebServiceClient implements Amaz
 
 		return invoke(request, responseHandler);
 	}
+
+    @Override
+        public UpdateTableResult updateTable(String tableName, ProvisionedThroughput provisionedThroughput)
+                 throws AmazonServiceException, AmazonClientException {
+
+                 throw new AmazonClientException("updateTable using String and ProvisionedThroughput is not implemented in Alternator.");
+        }
 
     @Override
 	public DeleteTableResult deleteTable(DeleteTableRequest deleteTableRequest)
@@ -231,6 +316,13 @@ public class AlternatorDBClientV2 extends AmazonWebServiceClient implements Amaz
 	}
 
     @Override
+        public DeleteTableResult deleteTable(String tableName)
+                 throws AmazonServiceException, AmazonClientException {
+
+                 throw new AmazonClientException("deleteTable using String is not implemented in Alternator.");
+        }
+
+    @Override
 	public DeleteItemResult deleteItem(DeleteItemRequest deleteItemRequest)
 			throws AmazonServiceException, AmazonClientException {
 		Request<DeleteItemRequest> request = new DeleteItemRequestMarshaller().marshall(deleteItemRequest);
@@ -240,6 +332,20 @@ public class AlternatorDBClientV2 extends AmazonWebServiceClient implements Amaz
 
 		return invoke(request, responseHandler);
 	}
+
+    @Override
+        public DeleteItemResult deleteItem(String tableName, java.util.Map<String,AttributeValue> key, String returnValues)
+                 throws AmazonServiceException, AmazonClientException {
+
+                 throw new AmazonClientException("deleteTable using String, Map, and String is not implemented in Alternator.");
+        }
+
+    @Override
+        public DeleteItemResult deleteItem(String tableName, java.util.Map<String,AttributeValue> key)
+                 throws AmazonServiceException, AmazonClientException {
+
+                 throw new AmazonClientException("deleteItem using String and Map is not implemented in Alternator.");
+        }
 
     @Override
 	public GetItemResult getItem(GetItemRequest getItemRequest)
@@ -253,6 +359,20 @@ public class AlternatorDBClientV2 extends AmazonWebServiceClient implements Amaz
 	}
 
     @Override
+        public GetItemResult getItem(String tableName, java.util.Map<String,AttributeValue> key, Boolean consistentRead)
+                 throws AmazonServiceException, AmazonClientException {
+
+                 throw new AmazonClientException("getItem using String, Map, and Boolean is not implemented in Alternator.");
+        }
+
+    @Override
+        public GetItemResult getItem(String tableName, java.util.Map<String,AttributeValue> key)
+                 throws AmazonServiceException, AmazonClientException {
+
+                 throw new AmazonClientException("getItem using String and Map is not implemented in Alternator.");
+        }
+
+    @Override
 	public BatchGetItemResult batchGetItem(BatchGetItemRequest batchGetItemRequest)
 			throws AmazonServiceException, AmazonClientException {
 		Request<BatchGetItemRequest> request = new BatchGetItemRequestMarshaller().marshall(batchGetItemRequest);
@@ -264,14 +384,49 @@ public class AlternatorDBClientV2 extends AmazonWebServiceClient implements Amaz
 	}
 
     @Override
+        public BatchGetItemResult batchGetItem(java.util.Map<String, KeysAndAttributes> requestItems)
+                 throws AmazonServiceException, AmazonClientException {
+
+                 throw new AmazonClientException("batchGetItem using Map is not implemented in Alternator.");
+        }
+
+    @Override
+        public BatchGetItemResult batchGetItem(java.util.Map<String, KeysAndAttributes> requestItems, String returnConsumedCapacity)
+                 throws AmazonServiceException, AmazonClientException {
+
+                 throw new AmazonClientException("batchGetItem using Map and String is not implemented in Alternator.");
+        }
+
+    @Override
 	public ListTablesResult listTables() throws AmazonServiceException, AmazonClientException {
 		return listTables(new ListTablesRequest());
 	}
 
-	@Override
+    @Override
 	public void setEndpoint(String endpoint) throws IllegalArgumentException {
-		super.setEndpoint(endpoint);
+		super.setEndpoint(endpoint, "dynamodb", null);
 	}
+
+    @Override
+        public ListTablesResult listTables(Integer limit)
+                 throws AmazonServiceException, AmazonClientException {
+
+                 throw new AmazonClientException("listTables using Integer is not implemented in Alternator.");
+        }
+
+    @Override
+        public ListTablesResult listTables(String exclusiveStartTableName, Integer limit)
+                 throws AmazonServiceException, AmazonClientException {
+
+                 throw new AmazonClientException("listTables using String and Integer is not implemented in Alternator.");
+        }
+
+    @Override
+        public ListTablesResult listTables(String exclusiveStartTableName)
+                 throws AmazonServiceException, AmazonClientException {
+
+                 throw new AmazonClientException("listTables using String is not implemented in Alternator.");
+        }
 
     @Override
 	public ResponseMetadata getCachedResponseMetadata(AmazonWebServiceRequest request) {
@@ -283,10 +438,11 @@ public class AlternatorDBClientV2 extends AmazonWebServiceClient implements Amaz
 
 		AmazonWebServiceRequest originalRequest = request.getOriginalRequest();
 
-		ExecutionContext executionContext = createExecutionContext();
-		executionContext.setCustomBackoffStrategy(com.amazonaws.internal.DynamoDBBackoffStrategy.DEFAULT);
+		ExecutionContext executionContext = createExecutionContext(request);
+//		executionContext.setCustomBackoffStrategy(com.amazonaws.internal.DynamoDBBackoffStrategy.DEFAULT);
 		JsonErrorResponseHandler errorResponseHandler = new JsonErrorResponseHandler(exceptionUnmarshallers);
 
-		return (X) client.execute(request, responseHandler, errorResponseHandler, executionContext);
+		Response<X> result = client.execute(request, responseHandler, errorResponseHandler, executionContext);
+                return result.getAwsResponse();
 	}
 }

--- a/src/main/java/com/michelboudreau/alternatorv2/AlternatorDBInProcessClientV2.java
+++ b/src/main/java/com/michelboudreau/alternatorv2/AlternatorDBInProcessClientV2.java
@@ -7,10 +7,14 @@ import com.amazonaws.AmazonWebServiceRequest;
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.ResponseMetadata;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import com.amazonaws.services.dynamodbv2.model.AttributeDefinition;
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.amazonaws.services.dynamodbv2.model.AttributeValueUpdate;
 import com.amazonaws.services.dynamodbv2.model.BatchGetItemRequest;
 import com.amazonaws.services.dynamodbv2.model.BatchGetItemResult;
 import com.amazonaws.services.dynamodbv2.model.BatchWriteItemRequest;
 import com.amazonaws.services.dynamodbv2.model.BatchWriteItemResult;
+import com.amazonaws.services.dynamodbv2.model.Condition;
 import com.amazonaws.services.dynamodbv2.model.CreateTableRequest;
 import com.amazonaws.services.dynamodbv2.model.CreateTableResult;
 import com.amazonaws.services.dynamodbv2.model.DeleteItemRequest;
@@ -21,8 +25,11 @@ import com.amazonaws.services.dynamodbv2.model.DescribeTableRequest;
 import com.amazonaws.services.dynamodbv2.model.DescribeTableResult;
 import com.amazonaws.services.dynamodbv2.model.GetItemRequest;
 import com.amazonaws.services.dynamodbv2.model.GetItemResult;
+import com.amazonaws.services.dynamodbv2.model.KeySchemaElement;
+import com.amazonaws.services.dynamodbv2.model.KeysAndAttributes;
 import com.amazonaws.services.dynamodbv2.model.ListTablesRequest;
 import com.amazonaws.services.dynamodbv2.model.ListTablesResult;
+import com.amazonaws.services.dynamodbv2.model.ProvisionedThroughput;
 import com.amazonaws.services.dynamodbv2.model.PutItemRequest;
 import com.amazonaws.services.dynamodbv2.model.PutItemResult;
 import com.amazonaws.services.dynamodbv2.model.QueryRequest;
@@ -33,6 +40,7 @@ import com.amazonaws.services.dynamodbv2.model.UpdateItemRequest;
 import com.amazonaws.services.dynamodbv2.model.UpdateItemResult;
 import com.amazonaws.services.dynamodbv2.model.UpdateTableRequest;
 import com.amazonaws.services.dynamodbv2.model.UpdateTableResult;
+import com.amazonaws.services.dynamodbv2.model.WriteRequest;
 import com.michelboudreau.alternator.AlternatorDBHandler;
 
 import org.apache.commons.logging.Log;
@@ -70,11 +78,29 @@ public class AlternatorDBInProcessClientV2 extends AmazonWebServiceClient implem
 		return handler.batchWriteItemV2(batchWriteItemRequest);
 	}
 
+        public BatchWriteItemResult batchWriteItem(java.util.Map<String,java.util.List<WriteRequest>> requestItems)
+                 throws AmazonServiceException, AmazonClientException {
+
+                 throw new AmazonClientException("batchWriteItem using Map is not implemented in Alternator.");
+        }
+
 	public UpdateItemResult updateItem(UpdateItemRequest updateItemRequest)
 			throws AmazonServiceException, AmazonClientException {
 
             return handler.updateItemV2(updateItemRequest);
 	}
+
+        public UpdateItemResult updateItem(String tableName, java.util.Map<String, AttributeValue> key, java.util.Map<String, AttributeValueUpdate> attributeUpdates, String returnValues)
+                 throws AmazonServiceException, AmazonClientException {
+
+                 throw new AmazonClientException("updateItem using String, Map, Map, and String is not implemented in Alternator.");
+        }
+
+        public UpdateItemResult updateItem(String tableName, java.util.Map<String,AttributeValue> key, java.util.Map<String,AttributeValueUpdate> attributeUpdates)
+                 throws AmazonServiceException, AmazonClientException {
+
+                 throw new AmazonClientException("updateItem using String, Map, and Map is not implemented in Alternator.");
+        }
 
 	public PutItemResult putItem(PutItemRequest putItemRequest)
 			throws AmazonServiceException, AmazonClientException {
@@ -82,15 +108,51 @@ public class AlternatorDBInProcessClientV2 extends AmazonWebServiceClient implem
             return handler.putItemV2(putItemRequest);
 }
 
+        public PutItemResult putItem(String tableName, java.util.Map<String,AttributeValue> item, String returnValues)
+                 throws AmazonServiceException, AmazonClientException {
+
+                 throw new AmazonClientException("putItem using String, Map, and String is not implemented in Alternator.");
+        }
+
+        public PutItemResult putItem(String tableName, java.util.Map<String,AttributeValue> item)
+                 throws AmazonServiceException, AmazonClientException {
+
+                 throw new AmazonClientException("putItem using String and Map is not implemented in Alternator.");
+        }
+
 	public DescribeTableResult describeTable(DescribeTableRequest describeTableRequest)
 			throws AmazonServiceException, AmazonClientException {
 		return handler.describeTableV2(describeTableRequest);
 	}
 
+       public DescribeTableResult describeTable(String tableName)
+                 throws AmazonServiceException, AmazonClientException {
+
+                 throw new AmazonClientException("describeTable using String is not implemented in Alternator.");
+        }
+
 	public ScanResult scan(ScanRequest scanRequest)
 			throws AmazonServiceException, AmazonClientException {
 		return handler.scanV2(scanRequest);
 	}
+
+        public ScanResult scan(String tableName, java.util.List<String> attributesToGet, java.util.Map<String,Condition> scanFilter)
+                 throws AmazonServiceException, AmazonClientException {
+
+                 throw new AmazonClientException("scan using String, List, and Map is not implemented in Alternator.");
+        }
+
+        public ScanResult scan(String tableName, java.util.Map<String,Condition> scanFilter)
+                 throws AmazonServiceException, AmazonClientException {
+
+                 throw new AmazonClientException("scan using String and Map is not implemented in Alternator.");
+        }
+
+        public ScanResult scan(String tableName, java.util.List<String> attributesToGet)
+                 throws AmazonServiceException, AmazonClientException {
+
+                 throw new AmazonClientException("scan using String and List is not implemented in Alternator.");
+        }
 
 	public CreateTableResult createTable(CreateTableRequest createTableRequest)
 			throws AmazonServiceException, AmazonClientException {
@@ -98,11 +160,23 @@ public class AlternatorDBInProcessClientV2 extends AmazonWebServiceClient implem
             return handler.createTableV2(createTableRequest);
 	}
 
+        public CreateTableResult createTable(java.util.List<AttributeDefinition> attributeDefinitions, String tableName, java.util.List<KeySchemaElement> keySchema, ProvisionedThroughput provisionedThroughput)
+                 throws AmazonServiceException, AmazonClientException {
+
+                 throw new AmazonClientException("createTable using List, String, List, and ProvisionedThroughput is not implemented in Alternator.");
+        }
+
 	public UpdateTableResult updateTable(UpdateTableRequest updateTableRequest)
 			throws AmazonServiceException, AmazonClientException {
 
             return handler.updateTableV2(updateTableRequest);
 	}
+
+        public UpdateTableResult updateTable(String tableName, ProvisionedThroughput provisionedThroughput)
+                 throws AmazonServiceException, AmazonClientException {
+
+                 throw new AmazonClientException("updateTable using String and ProvisionedThroughput is not implemented in Alternator.");
+        }
 
 	public DeleteTableResult deleteTable(DeleteTableRequest deleteTableRequest)
 			throws AmazonServiceException, AmazonClientException {
@@ -110,11 +184,29 @@ public class AlternatorDBInProcessClientV2 extends AmazonWebServiceClient implem
             return handler.deleteTableV2(deleteTableRequest);
 	}
 
+        public DeleteTableResult deleteTable(String tableName)
+                 throws AmazonServiceException, AmazonClientException {
+
+                 throw new AmazonClientException("deleteTable using String is not implemented in Alternator.");
+        }
+
 	public DeleteItemResult deleteItem(DeleteItemRequest deleteItemRequest)
 			throws AmazonServiceException, AmazonClientException {
 
             return handler.deleteItemV2(deleteItemRequest);
-    }
+        }
+
+        public DeleteItemResult deleteItem(String tableName, java.util.Map<String,AttributeValue> key, String returnValues)
+                 throws AmazonServiceException, AmazonClientException {
+
+                 throw new AmazonClientException("deleteTable using String, Map, and String is not implemented in Alternator.");
+        }
+
+        public DeleteItemResult deleteItem(String tableName, java.util.Map<String,AttributeValue> key)
+                 throws AmazonServiceException, AmazonClientException {
+
+                 throw new AmazonClientException("deleteItem using String and Map is not implemented in Alternator.");
+        }
 
 	public GetItemResult getItem(GetItemRequest getItemRequest)
 			throws AmazonServiceException, AmazonClientException {
@@ -122,14 +214,56 @@ public class AlternatorDBInProcessClientV2 extends AmazonWebServiceClient implem
             return handler.getItemV2(getItemRequest);
 	}
 
+        public GetItemResult getItem(String tableName, java.util.Map<String,AttributeValue> key, Boolean consistentRead)
+                 throws AmazonServiceException, AmazonClientException {
+
+                 throw new AmazonClientException("getItem using String, Map, and Boolean is not implemented in Alternator.");
+        }
+
+        public GetItemResult getItem(String tableName, java.util.Map<String,AttributeValue> key)
+                 throws AmazonServiceException, AmazonClientException {
+
+                 throw new AmazonClientException("getItem using String and Map is not implemented in Alternator.");
+        }
+
 	public BatchGetItemResult batchGetItem(BatchGetItemRequest batchGetItemRequest)
 			throws AmazonServiceException, AmazonClientException {
 		return handler.batchGetItemV2(batchGetItemRequest);
 	}
 
+        public BatchGetItemResult batchGetItem(java.util.Map<String, KeysAndAttributes> requestItems)
+                 throws AmazonServiceException, AmazonClientException {
+
+                 throw new AmazonClientException("batchGetItem using Map is not implemented in Alternator.");
+        }
+
+        public BatchGetItemResult batchGetItem(java.util.Map<String, KeysAndAttributes> requestItems, String returnConsumedCapacity)
+                 throws AmazonServiceException, AmazonClientException {
+
+                 throw new AmazonClientException("batchGetItem using Map and String is not implemented in Alternator.");
+        }
+
 	public ListTablesResult listTables() throws AmazonServiceException, AmazonClientException {
 		return handler.listTablesV2(new ListTablesRequest());
 	}
+
+        public ListTablesResult listTables(Integer limit)
+                 throws AmazonServiceException, AmazonClientException {
+
+                 throw new AmazonClientException("listTables using Integer is not implemented in Alternator.");
+        }
+
+        public ListTablesResult listTables(String exclusiveStartTableName, Integer limit)
+                 throws AmazonServiceException, AmazonClientException {
+
+                 throw new AmazonClientException("listTables using String and Integer is not implemented in Alternator.");
+        }
+
+        public ListTablesResult listTables(String exclusiveStartTableName)
+                 throws AmazonServiceException, AmazonClientException {
+
+                 throw new AmazonClientException("listTables using String is not implemented in Alternator.");
+        }
 
 	@Override
 	public void setEndpoint(String endpoint) throws IllegalArgumentException {


### PR DESCRIPTION
This addresses Issue #83 regarding use of version 1.6.8 or higher of the AWS SDK for Java:

  https://github.com/mboudreau/Alternator/issues/83 

The primary fix was to modify AlternatorDBClient.setEndpoint to explicitly pass "dynamodb" as the service name to the superclass to bypass new inference logic based on the class name of the client.  The same revision was also made to AlternatorDBClientV2.setEndpoint.

```
super.setEndpoint(endpoint, "dynamodb", null);
```

Also, the .invoke method in both client classes was revised to unwrap the Response<X> object now returned by the AmazonHttpClient.execute method.  (Version 1.6.4 simply returned an object of type X.)

```
Response<X> result = client.execute(request, responseHandler, errorResponseHandler, executionContext);
return result.getAwsResponse();
```

All tests pass using 'mvn verify', including an alternate run with AlternatorTest.SPAWN_LOCAL_DB_SERVICE temporarily compiled as false, with an instance of Alternator running in another terminal window via 'mvn exec:java'.

I updated the maven-compiler-plugin version to 3.1 to resolve an issue with setting the &lt;source&gt; and &lt;target&gt; to Java 1.5 to match the AWS SDK for Java settings.

I updated the snapshot version of Alternator to 0.8.0 since this involves referencing a new version of the AWS SDK for Java for client projects.

The AWS SDK for Java source code can be reviewed at their GitHub repository:

  https://github.com/aws/aws-sdk-java.git
