### PR TITLE
Fix typo in README pom.xml example dependency groupId.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ You can now add the dependency into your maven project with:
 
 	<dependencies>
 		<dependency>
-			<groupId>com.michelboureau</groupId>
+			<groupId>com.michelboudreau</groupId>
 			<artifactId>alternator</artifactId>
 			<version>0.9.0 <!-- subject to change, check sonatype repo --></version>
 			<scope>test</scope>


### PR DESCRIPTION
Credit goes to Lawrence Weetman for noticing this typing error in the pom.xml example excerpt to be inserted into client Maven projects.
