### PR TITLE
Support AWS SDK 1.10.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
 	<url>https://github.com/mboudreau/Alternator/</url>
 
 	<properties>
+		<additionalparam>-Xdoclint:none</additionalparam>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<aws.version>1.9.13</aws.version>
 		<jetty.version>9.2.0.v20140526</jetty.version>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 	<properties>
 		<additionalparam>-Xdoclint:none</additionalparam>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<aws.version>1.9.13</aws.version>
+		<aws.version>1.10.2</aws.version>
 		<jetty.version>9.2.0.v20140526</jetty.version>
 		<slf4j.version>1.7.0</slf4j.version>
 		<spring.framework.version>3.0.7.RELEASE</spring.framework.version>

--- a/src/main/java/com/michelboudreau/alternator/AlternatorDBClient.java
+++ b/src/main/java/com/michelboudreau/alternator/AlternatorDBClient.java
@@ -113,14 +113,18 @@ public class AlternatorDBClient extends AmazonWebServiceClient implements Amazon
 		HandlerChainFactory chainFactory = new HandlerChainFactory();
 		requestHandler2s.addAll(chainFactory.newRequestHandlerChain("/com/amazonaws/services/dynamodb/request.handlers"));
 
-		clientConfiguration = new ClientConfiguration(clientConfiguration);
-                clientConfiguration.setSignerOverride("NoOpSignerType");
-		if (clientConfiguration.getRetryPolicy() == ClientConfiguration.DEFAULT_RETRY_POLICY) {
+		ClientConfiguration customClientConfiguration = new ClientConfiguration(clientConfiguration);
+                customClientConfiguration.setSignerOverride("NoOpSignerType");
+		if (customClientConfiguration.getRetryPolicy() == ClientConfiguration.DEFAULT_RETRY_POLICY) {
 			log.debug("Overriding default max error retry value to: " + 10);
-			clientConfiguration.setMaxErrorRetry(10);
+			customClientConfiguration.setMaxErrorRetry(10);
 		}
-		setConfiguration(clientConfiguration);
+		setCustomConfiguration(customClientConfiguration);
 	}
+
+        private void setCustomConfiguration(ClientConfiguration customClientConfiguration) {
+            this.clientConfiguration = customClientConfiguration;
+        }
 
 	public ListTablesResult listTables(ListTablesRequest listTablesRequest)
 			throws AmazonServiceException, AmazonClientException {
@@ -269,7 +273,7 @@ public class AlternatorDBClient extends AmazonWebServiceClient implements Amazon
                 this.endpoint = endpointUri;
             }
 	}
-        
+
         /**
          * Internal method for implementing {@link #getServiceName()}. Method is
          * protected by intent so peculiar subclass that don't follow the class

--- a/src/main/java/com/michelboudreau/alternatorv2/AlternatorDBClientV2.java
+++ b/src/main/java/com/michelboudreau/alternatorv2/AlternatorDBClientV2.java
@@ -121,14 +121,18 @@ public class AlternatorDBClientV2 extends AmazonWebServiceClient implements Amaz
 		HandlerChainFactory chainFactory = new HandlerChainFactory();
 		requestHandler2s.addAll(chainFactory.newRequestHandlerChain("/com/amazonaws/services/dynamodb/request.handlers"));
 
-		clientConfiguration = new ClientConfiguration(clientConfiguration);
-                clientConfiguration.setSignerOverride("NoOpSignerType");
-		if (clientConfiguration.getRetryPolicy() == ClientConfiguration.DEFAULT_RETRY_POLICY) {
+		ClientConfiguration customClientConfiguration = new ClientConfiguration(clientConfiguration);
+                customClientConfiguration.setSignerOverride("NoOpSignerType");
+		if (customClientConfiguration.getRetryPolicy() == ClientConfiguration.DEFAULT_RETRY_POLICY) {
 			log.debug("Overriding default max error retry value to: " + 10);
-			clientConfiguration.setMaxErrorRetry(10);
+			customClientConfiguration.setMaxErrorRetry(10);
 		}
-		setConfiguration(clientConfiguration);
+		setCustomConfiguration(customClientConfiguration);
 	}
+
+        private void setCustomConfiguration(ClientConfiguration customClientConfiguration) {
+            this.clientConfiguration = customClientConfiguration;
+        }
 
     @Override
 	public ListTablesResult listTables(ListTablesRequest listTablesRequest)
@@ -416,7 +420,7 @@ public class AlternatorDBClientV2 extends AmazonWebServiceClient implements Amaz
                 this.endpoint = endpointUri;
             }
 	}
-        
+
         /**
          * Internal method for implementing {@link #getServiceName()}. Method is
          * protected by intent so peculiar subclass that don't follow the class


### PR DESCRIPTION
Addresses Issue 92: https://github.com/mboudreau/Alternator/issues/92

Alternator has several places where it accesses or overrides DynamoDB parent class protected properties and methods.

Amazon changed the internal signature of the AmazonWebServiceClient class in the com.amazonaws package.
The .setConfiguration method was removed.

To resolve this for Alternator, a new .setCustomConfiguration method was added; it directly access the protected .configuration property.

By using the name .setCustomConfiguration instead of .setConfiguration for the new method, the Alternator code compiles with both AWS SDK 1.9.13 and 1.10.2

In addition, the pom.xml contains the parameter -Xdoclint:none to disable the new Java 8 strict JavaDoc HTML tag validation.

All JUnit regression tests pass with this update.
