### PR TITLE
AWS 1.10.5.1 AmazonServiceException

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,26 @@ Of course, it's not always possible to just create the client, mapper and servic
 
 Then you only need to create the AlternatorDB service in your test and you're ready to test out your code.  Hope this helps out.  Please feel free to contribute or suggest ways to make the project better.
 
+### Running Alternator's own JUnit tests
+
+_This note applies to any developer working on a _clone_ of the Alternator GitHub project source code._
+
+The Maven **pom.xml** for Alternator declares the following property with default of _true_:
+
+    <skipUnitTests>true</skipUnitTests>
+
+It then references it in the entry for **maven-surefire-plugin**
+
+    <skipTests>${skipUnitTests}</skipTests>
+
+This means the following Maven command will skip tests by default, speeding up a local compile and install cycle for your local **.m2** repository:
+
+    mvn clean install
+
+To actually run the JUnit tests, use this Maven command:
+
+    mvn verify -DskipUnitTests=false
+
 ## Dual API Version Support
 
 Amazon created a new specification for the DynamoDB API that is _not_ backward compatible with the earlier version.

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Then you only need to create the AlternatorDB service in your test and you're re
 
 ### Running Alternator's own JUnit tests
 
-_This note applies to any developer working on a _clone_ of the Alternator GitHub project source code._
+_This note applies to any developer working on a clone of the Alternator GitHub project source code._
 
 The Maven **pom.xml** for Alternator declares the following property with default of _true_:
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,8 @@
 	<url>https://github.com/mboudreau/Alternator/</url>
 
 	<properties>
+		<!-- http://stackoverflow.com/questions/18734211/cannot-overwrite-pom-maven-surefire-plugin-from-command-line -->
+		<skipUnitTests>true</skipUnitTests>
 		<additionalparam>-Xdoclint:none</additionalparam>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<aws.version>1.10.2</aws.version>
@@ -119,7 +121,7 @@
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>2.13</version>
 				<configuration>
-					<skipTests>true</skipTests>
+					<skipTests>${skipUnitTests}</skipTests>
 					<includes>
 						<include>**/*TestSuite.java</include>
 					</includes>

--- a/src/test/java/com/michelboudreau/testv2/AlternatorBatchItemTest.java
+++ b/src/test/java/com/michelboudreau/testv2/AlternatorBatchItemTest.java
@@ -1,5 +1,6 @@
 package com.michelboudreau.testv2;
 
+import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.dynamodbv2.model.AttributeDefinition;
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import com.amazonaws.services.dynamodbv2.model.BatchGetItemRequest;
@@ -282,8 +283,17 @@ public class AlternatorBatchItemTest extends AlternatorTest {
         try {
             result = getClient().batchWriteItem(batchWriteItemRequest);
         } catch (ResourceNotFoundException ex) {
+            System.out.printf("Caught expected exception: %s = %s",
+                    ex.getClass().getSimpleName(), ex.getMessage());
             exceptionMessage = ex.getMessage();
+        } catch (AmazonServiceException ase) {
+            System.out.printf("Caught expected exception: %s = %s",
+                    ase.getClass().getSimpleName(), ase.getMessage());
+            Assert.assertEquals("Wrong Error Code in AmazonServiceException.",
+                    "ResourceNotFoundException", ase.getErrorCode());
+            exceptionMessage = ase.getMessage();
         }
+
         // Question: Is this the actual behavior of DynamoDB?
         Assert.assertNotNull("Expected an exception.", exceptionMessage);
         Assert.assertThat("Incorrect exception message.", exceptionMessage,

--- a/src/test/java/com/michelboudreau/testv2/AlternatorItemTest.java
+++ b/src/test/java/com/michelboudreau/testv2/AlternatorItemTest.java
@@ -326,6 +326,13 @@ public class AlternatorItemTest extends AlternatorTest {
 			client.putItem(new PutItemRequest(tableName, item).withExpected(expectedMap));
 			Assert.assertTrue(false);// Should have thrown a ConditionalCheckFailedException
 		} catch (ConditionalCheckFailedException ccfe) {
+                        System.out.printf("Caught expected exception: %s = %s",
+                                ccfe.getClass().getSimpleName(), ccfe.getMessage());
+		} catch (AmazonServiceException ase) {
+                        System.out.printf("Caught expected exception: %s = %s",
+                                ase.getClass().getSimpleName(), ase.getMessage());
+                        Assert.assertEquals("Wrong Error Code in AmazonServiceException.",
+                                "ConditionalCheckFailedException", ase.getErrorCode());
 		}
 	}
 

--- a/src/test/java/com/michelboudreau/testv2/AlternatorMapperTest.java
+++ b/src/test/java/com/michelboudreau/testv2/AlternatorMapperTest.java
@@ -1,5 +1,6 @@
 package com.michelboudreau.testv2;
 
+import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapperConfig;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBQueryExpression;
@@ -76,11 +77,17 @@ public class AlternatorMapperTest extends AlternatorTest
     @Test
     public void putItemWithHashKeyOverwriteItem()
     {
-		try {
+        try {
             createTable(hashTableName, createStringAttributeDefinition("code"));
-		} catch (ResourceInUseException riue) {
-			// The table is already created, do nothing
-		}
+        } catch (ResourceInUseException riue) {
+            System.out.printf("Caught expected exception: %s = %s",
+                    riue.getClass().getSimpleName(), riue.getMessage());
+        } catch (AmazonServiceException ase) {
+            System.out.printf("Caught expected exception: %s = %s",
+                    ase.getClass().getSimpleName(), ase.getMessage());
+            Assert.assertEquals("Wrong Error Code in AmazonServiceException.",
+                    "ResourceInUseException", ase.getErrorCode());
+        }
 
         TestClassWithHashKey value2a = new TestClassWithHashKey();
         value2a.setCode("hash2");
@@ -117,11 +124,17 @@ public class AlternatorMapperTest extends AlternatorTest
     @Test
     public void putItemWithHashKeyAndRangeKeyOverwriteItem()
     {
-		try {
+        try {
             createTable(hashRangeTableName, createStringAttributeDefinition("hashCode"), createStringAttributeDefinition("rangeCode"));
-		} catch (ResourceInUseException riue) {
-			// The table is already created
-		}
+        } catch (ResourceInUseException riue) {
+            System.out.printf("Caught expected exception: %s = %s",
+                    riue.getClass().getSimpleName(), riue.getMessage());
+        } catch (AmazonServiceException ase) {
+            System.out.printf("Caught expected exception: %s = %s",
+                    ase.getClass().getSimpleName(), ase.getMessage());
+            Assert.assertEquals("Wrong Error Code in AmazonServiceException.",
+                    "ResourceInUseException", ase.getErrorCode());
+        }
 
         TestClassWithHashRangeKey value2a = new TestClassWithHashRangeKey();
         value2a.setHashCode("hash2");

--- a/src/test/java/com/michelboudreau/testv2/AlternatorScanTest.java
+++ b/src/test/java/com/michelboudreau/testv2/AlternatorScanTest.java
@@ -1,5 +1,6 @@
 package com.michelboudreau.testv2;
 
+import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import com.amazonaws.services.dynamodbv2.model.ComparisonOperator;
 import com.amazonaws.services.dynamodbv2.model.Condition;
@@ -52,7 +53,13 @@ public class AlternatorScanTest extends AlternatorTest {
 		try {
 			getClient().deleteTable(del);
 		} catch (ResourceNotFoundException rnfe) {
-
+                        System.out.printf("Caught expected exception: %s = %s",
+                                rnfe.getClass().getSimpleName(), rnfe.getMessage());
+		} catch (AmazonServiceException ase) {
+                        System.out.printf("Caught expected exception: %s = %s",
+                                ase.getClass().getSimpleName(), ase.getMessage());
+                        Assert.assertEquals("Wrong Error Code in AmazonServiceException.",
+                                "ResourceNotFoundException", ase.getErrorCode());
 		}
     }
 


### PR DESCRIPTION
The AWS SDK for DynamoDB in this version has slightly changed its exception behavior for certain operations. Several operations now throw AmazonServiceException instead of a specific exception. The .getErrorCode() for the AmazonServiceException is the string name of the original specific exception.

This revision updates the JUnit tests to adapt to this change.

Also the maven-surefire-plugin setting was recently changed to skipTests = true.
This is handy for performing compile and install to local .m2 repository without running the full test suite.  Based on this link:

  http://stackoverflow.com/questions/18734211/cannot-overwrite-pom-maven-surefire-plugin-from-command-line

An override property is now defined to allow the tests to be run using this command:

    mvn verify -DskipUnitTests=false

The README.md file contains a new note about this.